### PR TITLE
chore: Use Ops.CollectStatus Event

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -82,6 +82,9 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, build_and_de
 async def test_remove_nrf_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
     assert ops_test.model
     await ops_test.model.remove_application(NRF_CHARM_NAME, block_until_done=True)
+    # Running config-changed hook with empty config to check whether _nrf_relation_breaking
+    # attribute will not be set to its default value
+    await ops_test.model.applications[APP_NAME].set_config({})
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)
 
 
@@ -106,6 +109,9 @@ async def test_restore_nrf_and_wait_for_active_status(ops_test: OpsTest, build_a
 async def test_remove_tls_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
     assert ops_test.model
     await ops_test.model.remove_application(TLS_PROVIDER_CHARM_NAME, block_until_done=True)
+    # Running config-changed hook with empty config to check whether _tls_relation_breaking
+    # attribute will not be set to its default value
+    await ops_test.model.applications[APP_NAME].set_config({})
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)
 
 
@@ -129,6 +135,9 @@ async def test_restore_tls_and_wait_for_active_status(ops_test: OpsTest, build_a
 async def test_remove_database_and_wait_for_blocked_status(ops_test: OpsTest, build_and_deploy):
     assert ops_test.model
     await ops_test.model.remove_application(DB_CHARM_NAME, block_until_done=True)
+    # Running config-changed hook with empty config to check whether _database_relation_breaking
+    # attribute will not be set to its default value
+    await ops_test.model.applications[APP_NAME].set_config({})
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=60)
 
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -62,6 +62,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="database", remote_app="mongodb")
         self.harness.container_pebble_ready("amf")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for fiveg-nrf relation"),
@@ -73,6 +74,7 @@ class TestCharm(unittest.TestCase):
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg-nrf", remote_app="mongodb")
         self.harness.container_pebble_ready("amf")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for database relation"),
@@ -85,6 +87,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_relation(relation_name="fiveg-nrf", remote_app="mongodb")
         self.harness.add_relation(relation_name="database", remote_app="mongodb")
         self.harness.container_pebble_ready("amf")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for certificates relation"),
@@ -108,7 +111,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("amf")
 
         self.harness.remove_relation(nrf_relation_id)
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for fiveg-nrf relation"),
@@ -136,7 +139,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("amf")
 
         self.harness.remove_relation(database_relation_id)
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus("Waiting for database relation"),
@@ -156,6 +159,7 @@ class TestCharm(unittest.TestCase):
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
         self.harness.container_pebble_ready("amf")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for the amf database to be available"),
@@ -177,6 +181,7 @@ class TestCharm(unittest.TestCase):
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
         self.harness.container_pebble_ready("amf")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for AMF database info to be available"),
@@ -200,6 +205,7 @@ class TestCharm(unittest.TestCase):
         )
         self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for NRF data to be available"),
@@ -223,6 +229,7 @@ class TestCharm(unittest.TestCase):
         )
         self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for storage to be attached"),
@@ -253,6 +260,7 @@ class TestCharm(unittest.TestCase):
         )
         self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             WaitingStatus("Waiting for certificates to be stored"),
@@ -445,6 +453,7 @@ class TestCharm(unittest.TestCase):
         )
         self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.model.unit.status,
             ActiveStatus(),
@@ -468,7 +477,7 @@ class TestCharm(unittest.TestCase):
         self._create_database_relation_and_populate_data()
 
         self.harness.container_pebble_ready(container_name="amf")
-
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.charm.unit.status,
             WaitingStatus("Waiting for pod IP address to be available"),
@@ -661,6 +670,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("amf")
         relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="n2-requirer")
         self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="n2-requirer/0")
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.charm.unit.status, BlockedStatus("Waiting for MetalLB to be enabled")
         )
@@ -827,11 +837,12 @@ class TestCharm(unittest.TestCase):
         patch_check_output.return_value = b"1.1.1.1"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg-nrf", remote_app="mongodb")
-        self.harness.add_relation(
+        certificate_relation_id = self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
         self._create_database_relation_and_populate_data()
-        self.harness.charm._on_certificates_relation_broken(event=Mock())
+        self.harness.remove_relation(certificate_relation_id)
+        self.harness.evaluate_status()
         self.assertEqual(
             self.harness.charm.unit.status, BlockedStatus("Waiting for certificates relation")
         )


### PR DESCRIPTION
# Description

This PR uses new ops feature CollectStatus Event to manage status Charm.  Event named collect_unit_status sets the status of charm automatically at the end of every hook.

Reference:
- https://ops.readthedocs.io/en/latest/#ops.CollectStatusEvent
- https://discourse.charmhub.io/t/how-to-set-a-charms-status/11771

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library