### PR TITLE
chore: Change interface name from fiveg-nrf to fiveg_nrf

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ juju deploy self-signed-certificates --channel=stable
 juju integrate sdcore-nrf-k8s:database mongodb-k8s
 juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-amf-k8s:database mongodb-k8s
-juju integrate sdcore-amf-k8s:fiveg-nrf sdcore-nrf-k8s:fiveg-nrf
+juju integrate sdcore-amf-k8s:fiveg_nrf sdcore-nrf-k8s:fiveg_nrf
 juju integrate sdcore-amf-k8s:certificates self-signed-certificates:certificates
 ```
 

--- a/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
+++ b/lib/charms/sdcore_nrf_k8s/v0/fiveg_nrf.py
@@ -37,7 +37,7 @@ class DummyFiveGNRFRequirerCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.nrf_requirer = NRFRequires(self, "fiveg-nrf")
+        self.nrf_requirer = NRFRequires(self, "fiveg_nrf")
         self.framework.observe(self.nrf_requirer.on.nrf_available, self._on_nrf_available)
 
     def _on_nrf_available(self, event: NRFAvailableEvent):
@@ -67,7 +67,7 @@ class DummyFiveGNRFProviderCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
-        self.nrf_provider = NRFProvides(self, "fiveg-nrf")
+        self.nrf_provider = NRFProvides(self, "fiveg_nrf")
         self.framework.observe(
             self.on.fiveg_nrf_relation_joined, self._on_fiveg_nrf_relation_joined
         )
@@ -110,7 +110,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -40,7 +40,7 @@ provides:
     interface: fiveg_n2
 
 requires:
-  fiveg-nrf:
+  fiveg_nrf:
     interface: fiveg_nrf
   database:
     interface: mongodb_client

--- a/src/charm.py
+++ b/src/charm.py
@@ -72,7 +72,7 @@ class AMFOperatorCharm(CharmBase):
             return
         self._amf_container_name = self._amf_service_name = "amf"
         self._amf_container = self.unit.get_container(self._amf_container_name)
-        self._nrf_requires = NRFRequires(charm=self, relation_name="fiveg-nrf")
+        self._nrf_requires = NRFRequires(charm=self, relation_name="fiveg_nrf")
         self.n2_provider = N2Provides(self, N2_RELATION_NAME)
         self._certificates = TLSCertificatesRequiresV3(self, "certificates")
         self._amf_metrics_endpoint = MetricsEndpointProvider(
@@ -175,7 +175,7 @@ class AMFOperatorCharm(CharmBase):
                 f"The following configurations are not valid: {invalid_configs}"
             )
             return
-        for relation in ["fiveg-nrf", "database", "certificates"]:
+        for relation in ["fiveg_nrf", "database", "certificates"]:
             if not self._relation_created(relation):
                 self.unit.status = BlockedStatus(f"Waiting for {relation} relation")
                 return
@@ -272,7 +272,7 @@ class AMFOperatorCharm(CharmBase):
         Args:
             event (NRFBrokenEvent): Juju event
         """
-        self.unit.status = BlockedStatus("Waiting for fiveg-nrf relation")
+        self.unit.status = BlockedStatus("Waiting for fiveg_nrf relation")
 
     def _on_database_relation_broken(self, event: EventBase) -> None:
         """Event handler for database relation broken.

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -10,27 +10,27 @@ output "app_name" {
 
 output "fiveg_nrf_endpoint" {
   description = "Name of the endpoint used to integrate with the NRF."
-  value = "fiveg-nrf"
+  value       = "fiveg_nrf"
 }
 
 output "database_endpoint" {
   description = "Name of the endpoint used to integrate with the database."
-  value = "database"
+  value       = "database"
 }
 
 output "certificates_endpoint" {
   description = "Name of the endpoint used to integrate with the TLS certificates provider."
-  value = "certificates"
+  value       = "certificates"
 }
 
 # Provided integration endpoints
 
 output "metrics_endpoint" {
   description = "Exposes the Prometheus metrics endpoint providing telemetry about the AMF instance."
-  value = "metrics-endpoint"
+  value       = "metrics-endpoint"
 }
 
 output "fiveg_n2_endpoint" {
   description = "Name of the endpoint used to provide information on connectivity to the N2 plane."
-  value = "fiveg-n2"
+  value       = "fiveg-n2"
 }

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -60,14 +60,14 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("amf")
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("Waiting for fiveg-nrf relation"),
+            BlockedStatus("Waiting for fiveg_nrf relation"),
         )
 
     def test_given_database_relation_not_created_when_pebble_ready_then_status_is_blocked(
         self,
     ):
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="mongodb")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="mongodb")
         self.harness.container_pebble_ready("amf")
         self.assertEqual(
             self.harness.model.unit.status,
@@ -78,7 +78,7 @@ class TestCharm(unittest.TestCase):
         self,
     ):
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="mongodb")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="mongodb")
         self.harness.add_relation(relation_name="database", remote_app="mongodb")
         self.harness.container_pebble_ready("amf")
         self.assertEqual(
@@ -99,7 +99,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        nrf_relation_id = self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        nrf_relation_id = self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
 
@@ -107,7 +107,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("Waiting for fiveg-nrf relation"),
+            BlockedStatus("Waiting for fiveg_nrf relation"),
         )
 
     @patch("charm.check_output")
@@ -124,7 +124,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         database_relation_id = self._create_database_relation_and_populate_data()
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
@@ -146,7 +146,7 @@ class TestCharm(unittest.TestCase):
         private_key = b"whatever key content"
         patch_generate_private_key.return_value = private_key
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(relation_name="database", remote_app="mongodb")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
@@ -167,7 +167,7 @@ class TestCharm(unittest.TestCase):
         patch_generate_private_key.return_value = private_key
         patch_is_resource_created.return_value = True
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(relation_name="database", remote_app="mongodb")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
@@ -190,7 +190,7 @@ class TestCharm(unittest.TestCase):
         patch_generate_private_key.return_value = private_key
         patch_is_resource_created.return_value = True
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -213,7 +213,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -243,7 +243,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="mongodb")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="mongodb")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -276,7 +276,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -317,7 +317,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -356,7 +356,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -387,7 +387,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -435,7 +435,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -456,7 +456,7 @@ class TestCharm(unittest.TestCase):
         self.harness.add_storage(storage_name="config", attach=True)
         patch_check_output.return_value = b""
         patch_nrf_url.return_value = "http://nrf:8081"
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -514,7 +514,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -558,7 +558,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -603,7 +603,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -648,7 +648,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -695,7 +695,7 @@ class TestCharm(unittest.TestCase):
         patch_is_resource_created.return_value = True
         patch_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -741,7 +741,7 @@ class TestCharm(unittest.TestCase):
         private_key = b"whatever key content"
         patch_generate_private_key.return_value = private_key
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="nrf")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
@@ -823,7 +823,7 @@ class TestCharm(unittest.TestCase):
         patch_nrf_url.return_value = "http://nrf:8081"
         patch_check_output.return_value = b"1.1.1.1"
         self.harness.set_can_connect(container="amf", val=True)
-        self.harness.add_relation(relation_name="fiveg-nrf", remote_app="mongodb")
+        self.harness.add_relation(relation_name="fiveg_nrf", remote_app="mongodb")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )


### PR DESCRIPTION
# Description

NRF and AMF use different relation names for fiveg_nrf interface. All the other charms uses fiveg_nrf. We need to use the same naming convention in all charms. For this reason interface name is changed from fiveg-nrf -> fiveg_nrf within this PR.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library