### PR TITLE
chore: build python packages during build

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -11,9 +11,7 @@ parts:
   charm:
     build-packages:
       - cargo
+      - libffi-dev
+      - libssl-dev
+      - pkg-config
       - rustc
-    charm-binary-python-packages:
-      - cryptography
-      - jsonschema
-      - pip
-      - setuptools


### PR DESCRIPTION
# Description

Use `build-packages` instead of pre-built binaries. This addresses a bug that we currently have building the charm:

## Error

```
Building wheel for cffi (pyproject.toml): finished with status 'error'
::    ::   error: subprocess-exited-with-error
::    ::
::    ::   × Building wheel for cffi (pyproject.toml) did not run successfully.
::    ::   │ exit code: 1
::    ::   ╰─> [39 lines of output]
::    ::       running bdist_wheel
::    ::       running build
::    ::       running build_py
::    ::       creating build
::    ::       creating build/lib.linux-x86_64-cpython-310
::    ::       creating build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/setuptools_ext.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/verifier.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/backend_ctypes.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/vengine_cpy.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/api.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/vengine_gen.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/_imp_emulation.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/recompiler.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/pkgconfig.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/lock.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/cparser.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/_shimmed_dist_utils.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/ffiplatform.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/error.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/model.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/__init__.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/commontypes.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/cffi_opcode.py -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/_cffi_include.h -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/parse_c_type.h -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/_embedding.h -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       copying src/cffi/_cffi_errors.h -> build/lib.linux-x86_64-cpython-310/cffi
::    ::       running build_ext
::    ::       building '_cffi_backend' extension
::    ::       creating build/temp.linux-x86_64-cpython-310
::    ::       creating build/temp.linux-x86_64-cpython-310/src
::    ::       creating build/temp.linux-x86_64-cpython-310/src/c
::    ::       x86_64-linux-gnu-gcc -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -fPIC -DFFI_BUILDING=1 -DUSE__THREAD -DHAVE_SYNC_SYNCHRONIZE -I/usr/include/ffi -I/usr/include/libffi -I/root/parts/charm/build/staging-venv/include -I/usr/include/python3.10 -c src/c/_cffi_backend.c -o build/temp.linux-x86_64-cpython-310/src/c/_cffi_backend.o
::    ::       src/c/_cffi_backend.c:15:10: fatal error: ffi.h: No such file or directory
::    ::          15 | #include <ffi.h>
::    ::             |          ^~~~~~~
::    ::       compilation terminated.
::    ::       error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
::    ::       [end of output]
::    ::
``` 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library