### PR TITLE
fix: Using charm name as DEFAULT_FIELD_MANAGER

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -68,9 +68,6 @@ CORE_NETWORK_SHORT_NAME = "SDCORE"
 N2_RELATION_NAME = "fiveg-n2"
 LOGGING_RELATION_NAME = "logging"
 
-# The default field manager set when using kubectl to create resources
-DEFAULT_FIELD_MANAGER = "controller"
-
 
 class AMFOperatorCharm(CharmBase):
     """Main class to describe juju event handling for the SD-Core AMF operator for K8s."""
@@ -224,7 +221,7 @@ class AMFOperatorCharm(CharmBase):
                     type="LoadBalancer",
                 ),
             ),
-            field_manager=DEFAULT_FIELD_MANAGER,
+            field_manager=self.model.app.name,
         )
         logger.info("Created/asserted existence of external AMF service")
 

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1262,7 +1262,7 @@ class TestCharm(unittest.TestCase):
                         type="LoadBalancer",
                     ),
                 ),
-                field_manager="controller",
+                field_manager="sdcore-amf-k8s",
             ),
         ]
 


### PR DESCRIPTION
# Description

The global constant called DEFAULT_FIELD_MANAGER is set to a default value which is `controller` refers the name of Juju controller that is not always correct.  Replacing  DEFAULT_FIELD_MANAGER with the charm name as it is the charm in charge of managing the field.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library