### PR TITLE
feat: Publish charm to branch on push

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -48,6 +48,21 @@ jobs:
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
 
+  publish-charm-on-push:
+    name: Publish Developer Charm To Branch
+    needs:
+      - lint-report
+      - static-analysis
+      - unit-tests-with-coverage
+      - integration-test
+    if: ${{ (github.ref_name != 'main') && (github.event_name == 'push') }}
+    uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
+    with:
+      branch-name: /${{ github.ref_name }}
+      charm-file-name: "sdcore-amf-k8s_ubuntu-22.04-amd64.charm"
+      track-name: 1.3
+    secrets: inherit
+
   lib-needs-publishing:
     runs-on: ubuntu-22.04
     outputs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -61,7 +61,8 @@ jobs:
       branch-name: /${{ github.ref_name }}
       charm-file-name: "sdcore-amf-k8s_ubuntu-22.04-amd64.charm"
       track-name: 1.3
-    secrets: inherit
+    secrets:
+      CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
 
   lib-needs-publishing:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
# Description

Adds a job that for

- any branch that is not main
- push events only

will publish the charm to a developer branch names 1.3/edge/<git-branch-name>

# Checklist:

- [X] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [X] I have performed a self-review of my own code
N/A I have made corresponding changes to the documentation
N/A I have added tests that validate the behaviour of the software
- [X] I validated that new and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
N/A I have bumped the version of the library