### PR TITLE
chore: bump to v1.4.0

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,7 +42,7 @@ jobs:
     uses: canonical/sdcore-github-workflows/.github/workflows/publish-charm.yaml@main
     with:
       charm-file-name: "sdcore-amf-k8s_ubuntu-22.04-amd64.charm"
-      track-name: 1.3
+      track-name: 1.4
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
 
@@ -58,7 +58,7 @@ jobs:
     with:
       branch-name: ${{ github.ref_name }}
       charm-file-name: "sdcore-amf-k8s_ubuntu-22.04-amd64.charm"
-      track-name: 1.3
+      track-name: 1.4
     secrets:
       CHARMCRAFT_AUTH: ${{ secrets.CHARMCRAFT_AUTH }}
 

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -14,7 +14,7 @@ on:
         type: choice
         description: Name of the charmhub track to publish
         options:
-          - 1.3
+          - 1.4
           - latest
 
 

--- a/README.md
+++ b/README.md
@@ -35,4 +35,4 @@ juju config sdcore-amf-k8s external-amf-ip=192.168.0.4 external-amf-hostname=amf
 
 ## Image
 
-**amf**: ghcr.io/canonical/sdcore-amf:1.3
+**amf**: ghcr.io/canonical/sdcore-amf:1.4.0

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -20,7 +20,7 @@ resources:
   amf-image:
     type: oci-image
     description: OCI image for SD-Core amf
-    upstream-source: ghcr.io/canonical/sdcore-amf:1.3
+    upstream-source: ghcr.io/canonical/sdcore-amf:1.4.0
 
 storage:
   config:

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -16,7 +16,7 @@ variable "app_name" {
 variable "channel" {
   description = "The channel to use when deploying a charm."
   type        = string
-  default     = "1.3/edge"
+  default     = "1.4/edge"
 }
 
 variable "config" {


### PR DESCRIPTION
# Description

Bump workload to v1.4.0 and publish charm to `1.4/edge` on Charmhub.

## Note

The charmhub `1.4` track was requested and created:
- https://discourse.charmhub.io/t/create-a-1-4-track-for-sd-core-charms/13790/2

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library