### PR TITLE
fix: tell type checkers that the config options are strings

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -7,7 +7,7 @@
 import logging
 from ipaddress import IPv4Address
 from subprocess import check_output
-from typing import Optional
+from typing import Optional, cast
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires  # type: ignore[import]
 from charms.loki_k8s.v1.loki_push_api import LogForwarder  # type: ignore[import]
@@ -503,13 +503,13 @@ class AMFOperatorCharm(CharmBase):
         return invalid_configs
 
     def _get_dnn_config(self) -> Optional[str]:
-        return self.model.config.get("dnn")
+        return cast(Optional[str], self.model.config.get("dnn"))
 
     def _get_external_amf_ip_config(self) -> Optional[str]:
-        return self.model.config.get("external-amf-ip")
+        return cast(Optional[str], self.model.config.get("external-amf-ip"))
 
     def _get_external_amf_hostname_config(self) -> Optional[str]:
-        return self.model.config.get("external-amf-hostname")
+        return cast(Optional[str], self.model.config.get("external-amf-hostname"))
 
     def _on_n2_relation_joined(self, event: RelationJoinedEvent) -> None:
         """Handles N2 relation joined event.


### PR DESCRIPTION
# Description

ops<=2.12 wrongly has `self.config[x]` typed as `str`, when actually it could be an int, float, bool, or str, depending on the config type. We're fixing this in [ops:#1183](https://github.com/canonical/operator/pull/1183), but that will break static checking that currently assumes that the config is a str (because ops doesn't validate the schema, so all options will be bool|int|float|str).

This PR adds a `typing.cast` call where the config values are loaded and used where the type should be str.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation N/A
- [ ] I have added tests that validate the behaviour of the software N/A
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules N/A
- [ ] I have bumped the version of the library N/A