### PR TITLE
chore: Move to codespell and ruff 

### DIFF
--- a/lib/charms/sdcore_amf_k8s/v0/fiveg_n2.py
+++ b/lib/charms/sdcore_amf_k8s/v0/fiveg_n2.py
@@ -112,7 +112,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 logger = logging.getLogger(__name__)
 """Schemas definition for the provider and requirer sides of the `fiveg_n2` interface.
@@ -152,7 +152,7 @@ class ProviderSchema(DataBagSchema):
 
 
 def data_is_valid(data: dict) -> bool:
-    """Returns whether data is valid.
+    """Return whether data is valid.
 
     Args:
         data (dict): Data to be validated.
@@ -179,7 +179,7 @@ class N2InformationAvailableEvent(EventBase):
         self.amf_port = amf_port
 
     def snapshot(self) -> dict:
-        """Returns snapshot."""
+        """Return snapshot."""
         return {
             "amf_ip_address": self.amf_ip_address,
             "amf_hostname": self.amf_hostname,
@@ -212,7 +212,7 @@ class N2Requires(Object):
         self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Handler triggered on relation changed event.
+        """Handle relation changed event.
 
         Args:
             event (RelationChangedEvent): Juju event.
@@ -229,7 +229,7 @@ class N2Requires(Object):
 
     @property
     def amf_ip_address(self) -> Optional[str]:
-        """Returns AMF IP address.
+        """Return AMF IP address.
 
         Returns:
             str: AMF IP address.
@@ -240,7 +240,7 @@ class N2Requires(Object):
 
     @property
     def amf_hostname(self) -> Optional[str]:
-        """Returns AMF hostname.
+        """Return AMF hostname.
 
         Returns:
             str: AMF hostname.
@@ -251,7 +251,7 @@ class N2Requires(Object):
 
     @property
     def amf_port(self) -> Optional[int]:
-        """Returns the port used to connect to the AMF host.
+        """Return the port used to connect to the AMF host.
 
         Returns:
             int: AMF port.
@@ -266,7 +266,7 @@ class N2Requires(Object):
         """Get relation data for the remote application.
 
         Args:
-            Relation: Juju relation object (optional).
+            relation: Juju relation object (optional).
 
         Returns:
             Dict: Relation data for the remote application
@@ -296,7 +296,7 @@ class N2Provides(Object):
         self.charm = charm
 
     def set_n2_information(self, amf_ip_address: str, amf_hostname: str, amf_port: int) -> None:
-        """Sets the hostname and the ngapp port in the application relation data.
+        """Set the hostname and the ngapp port in the application relation data.
 
         Args:
             amf_ip_address (str): AMF IP address.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,27 +9,29 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
+[tool.ruff]
 line-length = 99
-target-version = ["py38"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
+[tool.ruff.lint]
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
-# Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff.lint.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv", "lib/charms/data_platform_libs", "lib/charms/observability_libs", "lib/charms/prometheus_k8s", "lib/charms/sdcore_nrf_k8s"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore D107 Missing docstring in __init__
-ignore = ["D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
 
 [[tool.mypy.overrides]]
 module = ["ops.*", "kubernetes.*", "flatten_json.*", "git.*"]
@@ -38,3 +40,6 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = ["charms.*"]
 follow_imports = "silent"
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"

--- a/src/charm.py
+++ b/src/charm.py
@@ -78,7 +78,7 @@ class AMFOperatorCharm(CharmBase):
             # NOTE: In cases where leader status is lost before the charm is
             # finished processing all teardown events, this prevents teardown
             # event code from running. Luckily, for this charm, none of the
-            # teardown code is necessary to preform if we're removing the
+            # teardown code is necessary to perform if we're removing the
             # charm.
             return
         self._amf_container_name = self._amf_service_name = "amf"
@@ -129,7 +129,7 @@ class AMFOperatorCharm(CharmBase):
             # NOTE: In cases where leader status is lost before the charm is
             # finished processing all teardown events, this prevents teardown
             # event code from running. Luckily, for this charm, none of the
-            # teardown code is necessary to preform if we're removing the
+            # teardown code is necessary to perform if we're removing the
             # charm.
             event.add_status(BlockedStatus("Scaling is not implemented for this charm"))
             logger.info("Scaling is not implemented for this charm")
@@ -197,7 +197,7 @@ class AMFOperatorCharm(CharmBase):
         event.add_status(ActiveStatus())
 
     def ready_to_configure(self) -> bool:
-        """Returns whether the preconditions are met to proceed with the configuration.
+        """Return whether the preconditions are met to proceed with the configuration.
 
         Returns:
             ready_to_configure: True if all conditions are met else False
@@ -252,7 +252,7 @@ class AMFOperatorCharm(CharmBase):
         logger.info("Created/asserted existence of external AMF service")
 
     def _on_remove(self, event: RemoveEvent) -> None:
-        # NOTE: We want to preform this removal only if the last remaining unit
+        # NOTE: We want to perform this removal only if the last remaining unit
         # is removed. This charm does not support scaling, so it *should* be
         # the only unit.
         #
@@ -313,7 +313,7 @@ class AMFOperatorCharm(CharmBase):
             return
 
     def _is_config_update_required(self, content: str) -> bool:
-        """Decides whether config update is required by checking existence and config content.
+        """Decide whether config update is required by checking existence and config content.
 
         Args:
             content (str): desired config file content
@@ -328,7 +328,7 @@ class AMFOperatorCharm(CharmBase):
         return False
 
     def _config_file_is_written(self) -> bool:
-        """Returns whether the config file was written to the workload container.
+        """Return whether the config file was written to the workload container.
 
         Returns:
             bool: Whether the config file was written.
@@ -336,9 +336,9 @@ class AMFOperatorCharm(CharmBase):
         return bool(self._amf_container.exists(f"{CONFIG_DIR_PATH}/{CONFIG_FILE_NAME}"))
 
     def _is_certificate_update_required(self, provider_certificate) -> bool:
-        """Checks the provided certificate and existing certificate.
+        """Check the provided certificate and existing certificate.
 
-        Returns True if update is required.
+        Return True if update is required.
 
         Args:
             provider_certificate: str
@@ -348,11 +348,11 @@ class AMFOperatorCharm(CharmBase):
         return self._get_existing_certificate() != provider_certificate
 
     def _get_existing_certificate(self) -> str:
-        """Returns the existing certificate if present else empty string."""
+        """Return the existing certificate if present else empty string."""
         return self._get_stored_certificate() if self._certificate_is_stored() else ""
 
     def _configure_pebble(self, restart=False) -> None:
-        """Configures the Pebble layer.
+        """Configure the Pebble layer.
 
         Args:
             restart (bool): Whether to restart the AMF container.
@@ -367,7 +367,7 @@ class AMFOperatorCharm(CharmBase):
         self._amf_container.replan()
 
     def _on_certificates_relation_broken(self, event: RelationBrokenEvent) -> None:
-        """Deletes TLS related artifacts and reconfigures AMF."""
+        """Delete TLS related artifacts and reconfigures AMF."""
         if not self._amf_container.can_connect():
             event.defer()
             return
@@ -376,7 +376,7 @@ class AMFOperatorCharm(CharmBase):
         self._delete_certificate()
 
     def _on_certificate_expiring(self, event: CertificateExpiringEvent):
-        """Requests new certificate."""
+        """Request new certificate."""
         if not self._amf_container.can_connect():
             event.defer()
             return
@@ -386,7 +386,7 @@ class AMFOperatorCharm(CharmBase):
         self._request_new_certificate()
 
     def _get_current_provider_certificate(self) -> str | None:
-        """Compares the current certificate request to what is in the interface.
+        """Compare the current certificate request to what is in the interface.
 
         Returns The current valid provider certificate if present
         """
@@ -397,7 +397,7 @@ class AMFOperatorCharm(CharmBase):
         return None
 
     def _update_certificate(self, provider_certificate) -> bool:
-        """Compares the provided certificate to what is stored.
+        """Compare the provided certificate to what is stored.
 
         Returns True if the certificate was updated
         """
@@ -411,12 +411,12 @@ class AMFOperatorCharm(CharmBase):
         return False
 
     def _generate_private_key(self) -> None:
-        """Generates and stores private key."""
+        """Generate and stores private key."""
         private_key = generate_private_key()
         self._store_private_key(private_key)
 
     def _request_new_certificate(self) -> None:
-        """Generates and stores CSR, and uses it to request a new certificate."""
+        """Generate and stores CSR, and uses it to request a new certificate."""
         private_key = self._get_stored_private_key()
         csr = generate_csr(
             private_key=private_key,
@@ -427,59 +427,59 @@ class AMFOperatorCharm(CharmBase):
         self._certificates.request_certificate_creation(certificate_signing_request=csr)
 
     def _delete_private_key(self):
-        """Removes private key from workload."""
+        """Remove private key from workload."""
         if not self._private_key_is_stored():
             return
         self._amf_container.remove_path(path=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}")
         logger.info("Removed private key from workload")
 
     def _delete_csr(self):
-        """Deletes CSR from workload."""
+        """Delete CSR from workload."""
         if not self._csr_is_stored():
             return
         self._amf_container.remove_path(path=f"{CERTS_DIR_PATH}/{CSR_NAME}")
         logger.info("Removed CSR from workload")
 
     def _delete_certificate(self):
-        """Deletes certificate from workload."""
+        """Delete certificate from workload."""
         if not self._certificate_is_stored():
             return
         self._amf_container.remove_path(path=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}")
         logger.info("Removed certificate from workload")
 
     def _private_key_is_stored(self) -> bool:
-        """Returns whether private key is stored in workload."""
+        """Return whether private key is stored in workload."""
         return self._amf_container.exists(path=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}")
 
     def _csr_is_stored(self) -> bool:
-        """Returns whether CSR is stored in workload."""
+        """Return whether CSR is stored in workload."""
         return self._amf_container.exists(path=f"{CERTS_DIR_PATH}/{CSR_NAME}")
 
     def _get_stored_certificate(self) -> str:
-        """Returns stored certificate."""
+        """Return stored certificate."""
         return str(self._amf_container.pull(path=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}").read())
 
     def _get_stored_csr(self) -> str:
-        """Returns stored CSR."""
+        """Return stored CSR."""
         return self._amf_container.pull(path=f"{CERTS_DIR_PATH}/{CSR_NAME}").read()
 
     def _get_stored_private_key(self) -> bytes:
-        """Returns stored private key."""
+        """Return stored private key."""
         return str(
             self._amf_container.pull(path=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}").read()
         ).encode()
 
     def _certificate_is_stored(self) -> bool:
-        """Returns whether certificate is stored in workload."""
+        """Return whether certificate is stored in workload."""
         return self._amf_container.exists(path=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}")
 
     def _store_certificate(self, certificate: str) -> None:
-        """Stores certificate in workload."""
+        """Store certificate in workload."""
         self._amf_container.push(path=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}", source=certificate)
         logger.info("Pushed certificate pushed to workload")
 
     def _store_private_key(self, private_key: bytes) -> None:
-        """Stores private key in workload."""
+        """Store private key in workload."""
         self._amf_container.push(
             path=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}",
             source=private_key.decode(),
@@ -487,12 +487,12 @@ class AMFOperatorCharm(CharmBase):
         logger.info("Pushed private key to workload")
 
     def _store_csr(self, csr: bytes) -> None:
-        """Stores CSR in workload."""
+        """Store CSR in workload."""
         self._amf_container.push(path=f"{CERTS_DIR_PATH}/{CSR_NAME}", source=csr.decode().strip())
         logger.info("Pushed CSR to workload")
 
     def _get_invalid_configs(self) -> list[str]:
-        """Returns list of invalid configurations.
+        """Return list of invalid configurations.
 
         Returns:
             list: List of strings matching config keys.
@@ -512,7 +512,7 @@ class AMFOperatorCharm(CharmBase):
         return cast(Optional[str], self.model.config.get("external-amf-hostname"))
 
     def _on_n2_relation_joined(self, event: RelationJoinedEvent) -> None:
-        """Handles N2 relation joined event.
+        """Handle N2 relation joined event.
 
         Args:
             event (RelationJoinedEvent): Juju event
@@ -523,7 +523,7 @@ class AMFOperatorCharm(CharmBase):
             return
 
     def _get_n2_amf_ip(self) -> Optional[str]:
-        """Returns the IP to send for the N2 interface.
+        """Return the IP to send for the N2 interface.
 
         If a configuration is provided, it is returned, otherwise
         returns the IP of the external LoadBalancer Service.
@@ -536,7 +536,7 @@ class AMFOperatorCharm(CharmBase):
         return self._amf_external_service_ip()
 
     def _get_n2_amf_hostname(self) -> str:
-        """Returns the hostname to send for the N2 interface.
+        """Return the hostname to send for the N2 interface.
 
         If a configuration is provided, it is returned. If that is
         not available, returns the hostname of the external LoadBalancer
@@ -553,7 +553,7 @@ class AMFOperatorCharm(CharmBase):
         return self._amf_hostname()
 
     def _set_n2_information(self) -> None:
-        """Sets N2 information for the N2 relation."""
+        """Set N2 information for the N2 relation."""
         if not self._relation_created(N2_RELATION_NAME):
             return
         if not self._amf_service_is_running():
@@ -565,7 +565,7 @@ class AMFOperatorCharm(CharmBase):
         )
 
     def _generate_amf_config_file(self) -> str:
-        """Handles creation of the AMF config file based on a given template.
+        """Handle creation of the AMF config file based on a given template.
 
         Returns:
             content (str): desired config file content
@@ -602,7 +602,7 @@ class AMFOperatorCharm(CharmBase):
         dnn: str,
         scheme: str,
     ) -> str:
-        """Renders the AMF config file.
+        """Render the AMF config file.
 
         Args:
             database_name (str): Name of the AMF database.
@@ -638,7 +638,7 @@ class AMFOperatorCharm(CharmBase):
         return content
 
     def _push_config_file(self, content: str) -> None:
-        """Writes the AMF config file and pushes it to the container.
+        """Write the AMF config file and pushes it to the container.
 
         Args:
             content (str): Content of the config file.
@@ -650,7 +650,7 @@ class AMFOperatorCharm(CharmBase):
         logger.info("Pushed %s config file", CONFIG_FILE_NAME)
 
     def _relation_created(self, relation_name: str) -> bool:
-        """Returns True if the relation is created, False otherwise.
+        """Return True if the relation is created, False otherwise.
 
         Args:
             relation_name (str): Name of the relation.
@@ -661,7 +661,7 @@ class AMFOperatorCharm(CharmBase):
         return bool(self.model.relations.get(relation_name))
 
     def _config_file_content_matches(self, content: str) -> bool:
-        """Returns whether the amfcfg config file content matches the provided content.
+        """Return whether the amfcfg config file content matches the provided content.
 
         Returns:
             bool: Whether the amfcfg config file content matches
@@ -675,7 +675,7 @@ class AMFOperatorCharm(CharmBase):
 
     @property
     def _amf_pebble_layer(self) -> Layer:
-        """Returns pebble layer for the amf container.
+        """Return pebble layer for the amf container.
 
         Returns:
             Layer: Pebble Layer
@@ -694,7 +694,7 @@ class AMFOperatorCharm(CharmBase):
         )
 
     def _get_database_info(self) -> dict:
-        """Returns the database data.
+        """Return the database data.
 
         Returns:
             Dict: The database data.
@@ -704,7 +704,7 @@ class AMFOperatorCharm(CharmBase):
         return self._database.fetch_relation_data()[self._database.relations[0].id]
 
     def _database_is_available(self) -> bool:
-        """Returns True if the database is available.
+        """Return True if the database is available.
 
         Returns:
             bool: True if the database is available.
@@ -713,7 +713,7 @@ class AMFOperatorCharm(CharmBase):
 
     @property
     def _amf_environment_variables(self) -> dict:
-        """Returns environment variables for the amf container.
+        """Return environment variables for the amf container.
 
         Returns:
             dict: Environment variables.
@@ -729,7 +729,7 @@ class AMFOperatorCharm(CharmBase):
         }
 
     def _amf_hostname(self) -> str:
-        """Builds and returns the AMF hostname in the cluster.
+        """Build and returns the AMF hostname in the cluster.
 
         Returns:
             str: The AMF hostname.
@@ -737,7 +737,7 @@ class AMFOperatorCharm(CharmBase):
         return f"{self.model.app.name}-external.{self.model.name}.svc.cluster.local"
 
     def _amf_service_is_running(self) -> bool:
-        """Returns whether the AMF service is running.
+        """Return whether the AMF service is running.
 
         Returns:
             bool: Whether the AMF service is running.
@@ -751,7 +751,7 @@ class AMFOperatorCharm(CharmBase):
         return service.is_running()
 
     def _amf_external_service_ip(self) -> Optional[str]:
-        """Returns the external service IP.
+        """Return the external service IP.
 
         Returns:
             str/None: External Service IP if available else None
@@ -771,7 +771,7 @@ class AMFOperatorCharm(CharmBase):
             return None
 
     def _amf_external_service_hostname(self) -> Optional[str]:
-        """Returns the external service hostname.
+        """Return the external service hostname.
 
         Returns:
             str: External Service hostname if available else None
@@ -792,7 +792,7 @@ class AMFOperatorCharm(CharmBase):
 
 
 def _get_pod_ip() -> Optional[str]:
-    """Returns the pod IP using juju client.
+    """Return the pod IP using juju client.
 
     Returns:
         str: The pod IP.

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,15 +1,11 @@
-black
+codespell
 coverage[toml]
-flake8-docstrings
-flake8-builtins
-isort
 juju==3.4.0.0
 macaroonbakery==1.3.4  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
-pep8-naming
-pyproject-flake8
 pytest
 pytest-operator
+ruff
 types-PyYAML
 types-setuptools
 types-toml

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,8 +8,7 @@ asttokens==2.4.1
     # via stack-data
 bcrypt==4.1.2
     # via paramiko
-black==24.3.0
-    # via -r test-requirements.in
+
 cachetools==5.3.3
     # via google-auth
 certifi==2024.2.2
@@ -18,32 +17,25 @@ certifi==2024.2.2
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
-    # via black
+codespell==2.2.6
+    # via -r test-requirements.in
 coverage[toml]==7.4.4
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
 executing==2.0.1
     # via stack-data
-flake8==7.0.0
-    # via
-    #   flake8-builtins
-    #   flake8-docstrings
-    #   pep8-naming
-    #   pyproject-flake8
-flake8-builtins==2.5.0
-    # via -r test-requirements.in
-flake8-docstrings==1.7.0
-    # via -r test-requirements.in
 google-auth==2.28.1
     # via kubernetes
 hvac==2.1.0
@@ -51,17 +43,19 @@ hvac==2.1.0
 idna==3.6
     # via requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
 ipython==8.22.1
     # via ipdb
-isort==5.13.2
-    # via -r test-requirements.in
 jedi==0.19.1
     # via ipython
 jinja2==3.1.3
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.4.0.0
     # via
     #   -r test-requirements.in
@@ -73,16 +67,15 @@ macaroonbakery==1.3.4
     #   -r test-requirements.in
     #   juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.6
     # via ipython
-mccabe==0.7.0
-    # via flake8
 mypy==1.9.0
     # via -r test-requirements.in
 mypy-extensions==1.0.0
     # via
-    #   black
     #   mypy
     #   typing-inspect
 oauthlib==3.2.2
@@ -91,23 +84,19 @@ oauthlib==3.2.2
     #   requests-oauthlib
 packaging==23.2
     # via
-    #   black
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.4.0
     # via juju
 parso==0.8.3
     # via jedi
-pathspec==0.12.1
-    # via black
-pep8-naming==0.13.3
-    # via -r test-requirements.in
 pexpect==4.9.0
     # via ipython
-platformdirs==4.2.0
-    # via black
 pluggy==1.4.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.43
     # via ipython
 protobuf==4.25.3
@@ -123,14 +112,10 @@ pyasn1==0.5.1
     #   rsa
 pyasn1-modules==0.3.0
     # via google-auth
-pycodestyle==2.11.1
-    # via flake8
 pycparser==2.21
-    # via cffi
-pydocstyle==6.3.0
-    # via flake8-docstrings
-pyflakes==3.2.0
-    # via flake8
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
@@ -140,14 +125,13 @@ pynacl==1.5.0
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyproject-flake8==7.0.0
-    # via -r test-requirements.in
 pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
 pytest==8.1.1
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -161,6 +145,7 @@ pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   pytest-operator
@@ -174,6 +159,8 @@ requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
+ruff==0.3.5
+    # via -r test-requirements.in
 six==1.16.0
     # via
     #   asttokens
@@ -181,8 +168,6 @@ six==1.16.0
     #   macaroonbakery
     #   pymacaroons
     #   python-dateutil
-snowballstemmer==2.2.0
-    # via pydocstyle
 stack-data==0.6.3
     # via ipython
 toposort==1.10
@@ -210,6 +195,8 @@ urllib3==2.2.1
 wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
-    # via kubernetes
+    # via
+    #   -c requirements.txt
+    #   kubernetes
 websockets==12.0
     # via juju

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,12 +4,12 @@
 import unittest
 from unittest.mock import Mock, PropertyMock, call, patch
 
+from charm import AMFOperatorCharm
 from lightkube.models.core_v1 import ServicePort, ServiceSpec
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Service
 from ops import ActiveStatus, BlockedStatus, WaitingStatus, testing
 
-from charm import AMFOperatorCharm
 from lib.charms.tls_certificates_interface.v3.tls_certificates import ProviderCertificate
 
 
@@ -40,7 +40,7 @@ class TestCharm(unittest.TestCase):
 
     @staticmethod
     def _read_file(path: str) -> str:
-        """Reads a file and returns as a string.
+        """Read a file and returns as a string.
 
         Args:
             path (str): path to the file.

--- a/tox.ini
+++ b/tox.ini
@@ -29,15 +29,13 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 commands =
-    isort {[vars]all_path}
-    black {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
-    black --check --diff {[vars]all_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
 
 [testenv:static]
 description = Run static analysis checks


### PR DESCRIPTION
# Description

Move to ruff and codespell for linting. `pyproject-flake8` is currently broken on Python 3.12, making development on Noble break.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library