### PR TITLE
chore: enable codespell in charm's lib and enable line length check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ extend-ignore = [
     "D204",
     "D213",
     "D215",
+    "D107",
     "D400",
     "D404",
     "D406",
@@ -27,7 +28,6 @@ extend-ignore = [
     "D409",
     "D413",
 ]
-ignore = ["E501", "D107"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
 [tool.ruff.lint.mccabe]

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ commands =
 [testenv:lint]
 description = Check code against coding style standards
 commands =
+    codespell {[vars]lib_path}
     codespell {tox_root}
     ruff check {[vars]all_path}
 


### PR DESCRIPTION
# Description

Execute codespell over the charm's library on the tox.ini file.
Enable line length check (E501)

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library