### PR TITLE
chore: Remove duplicated collect-status observation

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -99,7 +99,6 @@ class AMFOperatorCharm(CharmBase):
             self, relation_name="database", database_name=DATABASE_NAME
         )
         self._logging = LogForwarder(charm=self, relation_name=LOGGING_RELATION_NAME)
-        self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.remove, self._on_remove)
         self.framework.observe(self.on.config_changed, self._configure_amf)


### PR DESCRIPTION
# Description

The Collect unit status is being observed twice in the charm constructor. This PR eliminates the duplicated event observation.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library