### PR TITLE
chore: use pytest for unit tests

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -33,6 +33,7 @@ class TestCharm:
     patcher_generate_private_key = patch("charm.generate_private_key")
     patcher_get_assigned_certificates = patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates")  # noqa: E501
     patcher_request_certificate_creation = patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation")  # noqa: E501
+    patcher_client = patch("lightkube.core.client.GenericSyncClient", new=Mock)
     patcher_get = patch("lightkube.core.client.Client.get")
     patcher_apply = patch("lightkube.core.client.Client.apply")
     patcher_delete = patch("lightkube.core.client.Client.delete")
@@ -46,6 +47,7 @@ class TestCharm:
         self.mock_is_resource_created = TestCharm.patcher_is_resource_created.start()
         self.mock_nrf_url = TestCharm.patcher_nrf_url.start()
         self.mock_check_output = TestCharm.patcher_check_output.start()
+        TestCharm.patcher_client.start()
         self.mock_get = TestCharm.patcher_get.start()
         self.mock_apply = TestCharm.patcher_apply.start()
         self.mock_delete = TestCharm.patcher_delete.start()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -87,18 +87,18 @@ class TestCharm:
                 "uris": "http://dummy",
             },
         )
-        return database_relation_id
+        yield database_relation_id
 
     @pytest.fixture()
     def nrf_relation_id(self) -> int:
-        return self.harness.add_relation(
+        yield self.harness.add_relation(
             relation_name=NRF_RELATION_NAME,
             remote_app=DB_APPLICATION_NAME,
         )
 
     @pytest.fixture()
     def certificates_relation_id(self) -> int:
-        return self.harness.add_relation(
+        yield self.harness.add_relation(
             relation_name=TLS_RELATION_NAME,
             remote_app=TLS_APPLICATION_NAME,
         )

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1,9 +1,9 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import unittest
 from unittest.mock import Mock, PropertyMock, call, patch
 
+import pytest
 from charm import AMFOperatorCharm
 from lightkube.models.core_v1 import ServicePort, ServiceSpec
 from lightkube.models.meta_v1 import ObjectMeta
@@ -12,24 +12,66 @@ from ops import ActiveStatus, BlockedStatus, WaitingStatus, testing
 
 from lib.charms.tls_certificates_interface.v3.tls_certificates import ProviderCertificate
 
+DB_APPLICATION_NAME = "mongodb-k8s"
+DB_RELATION_NAME = "database"
+NAMESPACE = "whatever"
+PRIVATE_KEY = b"whatever key content"
+CSR = b"whatever csr content"
+CERTIFICATE = "Whatever certificate content"
 
-class TestCharm(unittest.TestCase):
-    def setUp(self):
-        self.namespace = "whatever"
+
+class TestCharm:
+    patcher_check_output = patch("charm.check_output")
+    patcher_nrf_url = patch(
+        "charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url",
+        new_callable=PropertyMock
+    )
+    patcher_is_resource_created = patch(
+        "charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created"
+    )
+    patcher_generate_csr = patch("charm.generate_csr")
+    patcher_generate_private_key = patch("charm.generate_private_key")
+    patcher_get_assigned_certificates = patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates")  # noqa: E501
+    patcher_request_certificate_creation = patch("charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation")  # noqa: E501
+    patcher_get = patch("lightkube.core.client.Client.get")
+    patcher_apply = patch("lightkube.core.client.Client.apply")
+    patcher_delete = patch("lightkube.core.client.Client.delete")
+
+    @pytest.fixture()
+    def setup(self):
+        self.mock_generate_csr = TestCharm.patcher_generate_csr.start()
+        self.mock_generate_private_key = TestCharm.patcher_generate_private_key.start()
+        self.mock_get_assigned_certificates = TestCharm.patcher_get_assigned_certificates.start()
+        self.mock_request_certificate_creation = TestCharm.patcher_request_certificate_creation.start()  # noqa: E501
+        self.mock_is_resource_created = TestCharm.patcher_is_resource_created.start()
+        self.mock_nrf_url = TestCharm.patcher_nrf_url.start()
+        self.mock_check_output = TestCharm.patcher_check_output.start()
+        self.mock_get = TestCharm.patcher_get.start()
+        self.mock_apply = TestCharm.patcher_apply.start()
+        self.mock_delete = TestCharm.patcher_delete.start()
+
+    @staticmethod
+    def teardown() -> None:
+        patch.stopall()
+
+    @pytest.fixture(autouse=True)
+    def harness(self, setup, request):
         self.harness = testing.Harness(AMFOperatorCharm)
-        self.harness.set_model_name(name=self.namespace)
-        self.addCleanup(self.harness.cleanup)
+        self.harness.set_model_name(name=NAMESPACE)
         self.harness.set_leader(is_leader=True)
         self.harness.begin()
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.teardown)
 
     def _create_database_relation_and_populate_data(self) -> int:
-        database_relation_id = self.harness.add_relation("database", "mongodb")
+        database_relation_id = self.harness.add_relation(DB_RELATION_NAME, DB_APPLICATION_NAME)
         self.harness.add_relation_unit(
-            relation_id=database_relation_id, remote_unit_name="mongodb/0"
+            relation_id=database_relation_id, remote_unit_name=f"{DB_APPLICATION_NAME}/0"
         )
         self.harness.update_relation_data(
             relation_id=database_relation_id,
-            app_or_unit="mongodb",
+            app_or_unit=DB_APPLICATION_NAME,
             key_values={
                 "username": "dummy",
                 "password": "dummy",
@@ -53,54 +95,39 @@ class TestCharm(unittest.TestCase):
         return content
 
     def test_given_fiveg_nrf_relation_not_created_when_pebble_ready_then_status_is_blocked(
-        self,
+        self
     ):
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="database", remote_app="mongodb")
         self.harness.container_pebble_ready("amf")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for fiveg_nrf relation"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation")
 
     def test_given_database_relation_not_created_when_pebble_ready_then_status_is_blocked(
-        self,
+        self
     ):
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="mongodb")
         self.harness.container_pebble_ready("amf")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for database relation"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for database relation")
 
     def test_given_certificates_relation_not_created_when_pebble_ready_then_status_is_blocked(
-        self,
+        self
     ):
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="mongodb")
         self.harness.add_relation(relation_name="database", remote_app="mongodb")
         self.harness.container_pebble_ready("amf")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for certificates relation"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for certificates relation")
 
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_amf_charm_in_active_state_when_nrf_relation_breaks_then_status_is_blocked(
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_check_output,
+        self
     ):
-        patch_check_output.return_value = b"1.1.1.1"
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_check_output.return_value = b"1.1.1.1"
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         nrf_relation_id = self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self._create_database_relation_and_populate_data()
@@ -109,24 +136,15 @@ class TestCharm(unittest.TestCase):
         self.harness.remove_relation(nrf_relation_id)
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for fiveg_nrf relation"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation")
 
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_amf_charm_in_active_state_when_database_relation_breaks_then_status_is_blocked(
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_check_output,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
-        patch_check_output.return_value = b"1.1.1.1"
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_check_output.return_value = b"1.1.1.1"
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         database_relation_id = self._create_database_relation_and_populate_data()
@@ -137,40 +155,30 @@ class TestCharm(unittest.TestCase):
 
         self.harness.remove_relation(database_relation_id)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Waiting for database relation"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for database relation")
 
-    @patch("charm.generate_private_key")
     def test_given_relations_created_and_database_not_available_when_pebble_ready_then_status_is_waiting(  # noqa: E501
-        self, patch_generate_private_key
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
-        self.harness.add_relation(relation_name="database", remote_app="mongodb")
+        self.harness.add_relation(relation_name=DB_RELATION_NAME, remote_app=DB_APPLICATION_NAME)
+        self.mock_is_resource_created.return_value = False
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
         )
         self.harness.container_pebble_ready("amf")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for the amf database to be available"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for the amf database to be available")  # noqa: E501
 
-    @patch("charm.generate_private_key")
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_database_info_not_available_when_pebble_ready_then_status_is_waiting(
-        self, patch_is_resource_created, patch_generate_private_key
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
-        patch_is_resource_created.return_value = True
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_is_resource_created.return_value = True
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(relation_name="database", remote_app="mongodb")
@@ -179,22 +187,15 @@ class TestCharm(unittest.TestCase):
         )
         self.harness.container_pebble_ready("amf")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for AMF database info to be available"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for AMF database info to be available")  # noqa: E501
 
-    @patch("charm.generate_private_key")
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_nrf_data_not_available_when_pebble_ready_then_status_is_waiting(
-        self,
-        patch_is_resource_created,
-        patch_generate_private_key,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
-        patch_is_resource_created.return_value = True
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = ""
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
@@ -203,22 +204,15 @@ class TestCharm(unittest.TestCase):
         self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for NRF data to be available"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for NRF data to be available")  # noqa: E501
 
-    @patch("charm.generate_private_key")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_storage_not_attached_when_pebble_ready_then_status_is_waiting(
-        self, patch_is_resource_created, patch_nrf_url, patch_generate_private_key
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
@@ -227,33 +221,18 @@ class TestCharm(unittest.TestCase):
         self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for storage to be attached"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for storage to be attached")  # noqa: E501
 
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
-    @patch("charm.generate_private_key")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_certificates_not_stored_when_pebble_ready_then_status_is_waiting(
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_generate_private_key,
-        patch_check_output,
-        patch_generate_csr,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
-        patch_check_output.return_value = b"1.1.1.1"
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
+        self.mock_check_output.return_value = b"1.1.1.1"
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="mongodb")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
@@ -262,44 +241,25 @@ class TestCharm(unittest.TestCase):
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.container_pebble_ready("amf")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for certificates to be stored"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for certificates to be stored")  # noqa: E501
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
-    @patch("charm.generate_private_key")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_relations_created_and_database_available_and_nrf_data_available_and_certs_stored_when_pebble_ready_then_config_file_rendered_and_pushed_correctly(  # noqa: E501
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_generate_private_key,
-        patch_check_output,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
-        patch_check_output.return_value = b"1.1.1.1"
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_check_output.return_value = b"1.1.1.1"
         certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
@@ -312,52 +272,33 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready("amf")
         with open("tests/unit/expected_config/config.conf") as expected_config_file:
             expected_content = expected_config_file.read()
-        self.assertEqual((root / "support/TLS/amf.key").read_text(), private_key.decode())
-        self.assertEqual((root / "support/TLS/amf.pem").read_text(), certificate)
-        self.assertEqual(
-            (root / "free5gc/config/amfcfg.conf").read_text(), expected_content.strip()
-        )
+        assert (root / "support/TLS/amf.key").read_text() == PRIVATE_KEY.decode()
+        assert (root / "support/TLS/amf.pem").read_text() == certificate
+        assert (root / "free5gc/config/amfcfg.conf").read_text() == expected_content.strip()
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
-    @patch("charm.generate_private_key")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_content_of_config_file_not_changed_when_pebble_ready_then_config_file_is_not_pushed(  # noqa: E501
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_generate_private_key,
-        patch_check_output,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
-        certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
         root = self.harness.get_filesystem_root("amf")
-        (root / "support/TLS/amf.pem").write_text(certificate)
+        (root / "support/TLS/amf.pem").write_text(CERTIFICATE)
         root = self.harness.get_filesystem_root("amf")
         (root / "free5gc/config/amfcfg.conf").write_text(
             self._read_file("tests/unit/expected_config/config.conf").strip()
         )
         config_modification_time = (root / "free5gc/config/amfcfg.conf").stat().st_mtime
-        patch_check_output.return_value = b"1.1.1.1"
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_check_output.return_value = b"1.1.1.1"
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
@@ -365,44 +306,29 @@ class TestCharm(unittest.TestCase):
         )
         self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
-        self.assertEqual(
-            (root / "free5gc/config/amfcfg.conf").stat().st_mtime, config_modification_time
-        )
+        assert (root / "free5gc/config/amfcfg.conf").stat().st_mtime == config_modification_time
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_relations_available_and_config_pushed_when_pebble_ready_then_pebble_is_applied_correctly(  # noqa: E501
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_check_output,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
         root = self.harness.get_filesystem_root("amf")
-        (root / "support/TLS/amf.pem").write_text(certificate)
+        (root / "support/TLS/amf.pem").write_text(CERTIFICATE)
         (root / "free5gc/config/amfcfg.conf").write_text(
             self._read_file("tests/unit/expected_config/config.conf").strip()
         )
-        patch_check_output.return_value = b"1.1.1.1"
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_check_output.return_value = b"1.1.1.1"
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
@@ -429,43 +355,30 @@ class TestCharm(unittest.TestCase):
             }
         }
         updated_plan = self.harness.get_container_pebble_plan("amf").to_dict()
-        self.assertEqual(expected_plan, updated_plan)
+        assert expected_plan == updated_plan
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_relations_available_and_config_pushed_and_pebble_updated_when_pebble_ready_then_status_is_active(  # noqa: E501
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_check_output,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        certificate = "Whatever certificate content"
-        patch_check_output.return_value = b"1.1.1.1"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_check_output.return_value = b"1.1.1.1"
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
         root = self.harness.get_filesystem_root("amf")
-        (root / "support/TLS/amf.pem").write_text(certificate)
+        (root / "support/TLS/amf.pem").write_text(CERTIFICATE)
         (root / "free5gc/config/amfcfg.conf").write_text(
             self._read_file("tests/unit/expected_config/config.conf").strip()
         )
-        patch_check_output.return_value = b"1.1.1.1"
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_check_output.return_value = b"1.1.1.1"
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
@@ -474,21 +387,14 @@ class TestCharm(unittest.TestCase):
         self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            ActiveStatus(),
-        )
+        assert self.harness.model.unit.status == ActiveStatus()
 
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
     def test_given_empty_ip_address_when_pebble_ready_then_status_is_waiting(
-        self,
-        patch_nrf_url,
-        patch_check_output,
+        self
     ):
         self.harness.add_storage(storage_name="config", attach=True)
-        patch_check_output.return_value = b""
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_check_output.return_value = b""
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
             relation_name="certificates", remote_app="tls-certificates-operator"
@@ -497,69 +403,48 @@ class TestCharm(unittest.TestCase):
 
         self.harness.container_pebble_ready(container_name="amf")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.charm.unit.status,
-            WaitingStatus("Waiting for pod IP address to be available"),
-        )
+        assert self.harness.charm.unit.status == WaitingStatus("Waiting for pod IP address to be available")  # noqa: E501
 
-    @patch("lightkube.core.client.Client.get")
-    @patch("charm.check_output")
     def test_given_service_not_running_when_fiveg_n2_relation_joined_then_n2_information_is_not_in_relation_databag(  # noqa: E501
-        self, patch_check_output, patch_get
+        self
     ):
-        patch_check_output.return_value = b"1.1.1.1"
+        self.mock_check_output.return_value = b"1.1.1.1"
         service = Mock(
             status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
         )
-        patch_get.return_value = service
+        self.mock_get.return_value = service
         relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="n2-requirer")
         self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="n2-requirer/0")
         relation_data = self.harness.get_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name
         )
-        self.assertEqual(relation_data, {})
+        assert relation_data == {}
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch("lightkube.core.client.Client.get")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_n2_information_and_service_is_running_when_fiveg_n2_relation_joined_then_n2_information_is_in_relation_databag(  # noqa: E501
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_check_output,
-        patch_get,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
         root = self.harness.get_filesystem_root("amf")
-        (root / "support/TLS/amf.pem").write_text(certificate)
+        (root / "support/TLS/amf.pem").write_text(CERTIFICATE)
         (root / "free5gc/config/amfcfg.conf").write_text(
             self._read_file("tests/unit/expected_config/config.conf").strip()
         )
-        patch_check_output.return_value = b"1.1.1.1"
+        self.mock_check_output.return_value = b"1.1.1.1"
         service = Mock(
             status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
         )
-        patch_get.return_value = service
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_get.return_value = service
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
@@ -573,51 +458,35 @@ class TestCharm(unittest.TestCase):
         relation_data = self.harness.get_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name
         )
-        self.assertEqual(relation_data["amf_ip_address"], "1.1.1.1")
-        self.assertEqual(relation_data["amf_hostname"], "amf.pizza.com")
-        self.assertEqual(relation_data["amf_port"], "38412")
+        assert relation_data["amf_ip_address"] == "1.1.1.1"
+        assert relation_data["amf_hostname"] == "amf.pizza.com"
+        assert relation_data["amf_port"] == "38412"
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch("lightkube.core.client.Client.get")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_n2_information_and_service_is_running_and_n2_config_is_overriden_when_fiveg_n2_relation_joined_then_custom_n2_information_is_in_relation_databag(  # noqa: E501
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_check_output,
-        patch_get,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
         root = self.harness.get_filesystem_root("amf")
-        (root / "support/TLS/amf.pem").write_text(certificate)
+        (root / "support/TLS/amf.pem").write_text(CERTIFICATE)
         (root / "free5gc/config/amfcfg.conf").write_text(
             self._read_file("tests/unit/expected_config/config.conf").strip()
         )
-        patch_check_output.return_value = b"1.1.1.1"
+        self.mock_check_output.return_value = b"1.1.1.1"
         service = Mock(
             status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
         )
-        patch_get.return_value = service
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_get.return_value = service
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
@@ -634,49 +503,33 @@ class TestCharm(unittest.TestCase):
         relation_data = self.harness.get_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name
         )
-        self.assertEqual(relation_data["amf_ip_address"], "2.2.2.2")
-        self.assertEqual(relation_data["amf_hostname"], "amf.burger.com")
-        self.assertEqual(relation_data["amf_port"], "38412")
+        assert relation_data["amf_ip_address"] == "2.2.2.2"
+        assert relation_data["amf_hostname"] == "amf.burger.com"
+        assert relation_data["amf_port"] == "38412"
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch("lightkube.core.client.Client.get")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_n2_information_and_service_is_running_and_lb_service_has_no_hostname_when_fiveg_n2_relation_joined_then_internal_service_hostname_is_used(  # noqa: E501
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_check_output,
-        patch_get,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
         root = self.harness.get_filesystem_root("amf")
-        (root / "support/TLS/amf.pem").write_text(certificate)
+        (root / "support/TLS/amf.pem").write_text(CERTIFICATE)
         (root / "free5gc/config/amfcfg.conf").write_text(
             self._read_file("tests/unit/expected_config/config.conf").strip()
         )
-        patch_check_output.return_value = b"1.1.1.1"
+        self.mock_check_output.return_value = b"1.1.1.1"
         service = Mock(status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", spec=["ip"])])))
-        patch_get.return_value = service
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_get.return_value = service
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
@@ -691,51 +544,33 @@ class TestCharm(unittest.TestCase):
         relation_data = self.harness.get_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name
         )
-        self.assertEqual(relation_data["amf_ip_address"], "2.2.2.2")
-        self.assertEqual(
-            relation_data["amf_hostname"], "sdcore-amf-k8s-external.whatever.svc.cluster.local"
-        )
-        self.assertEqual(relation_data["amf_port"], "38412")
+        assert relation_data["amf_ip_address"] == "2.2.2.2"
+        assert relation_data["amf_hostname"] == "sdcore-amf-k8s-external.whatever.svc.cluster.local"  # noqa: E501
+        assert relation_data["amf_port"] == "38412"
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch("lightkube.core.client.Client.get")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_n2_information_and_service_is_running_and_metallb_service_is_not_available_when_fiveg_n2_relation_joined_then_amf_goes_in_blocked_state(  # noqa: E501
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_check_output,
-        patch_get,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
         root = self.harness.get_filesystem_root("amf")
-        (root / "support/TLS/amf.pem").write_text(certificate)
+        (root / "support/TLS/amf.pem").write_text(CERTIFICATE)
         (root / "free5gc/config/amfcfg.conf").write_text(
             self._read_file("tests/unit/expected_config/config.conf").strip()
         )
-        patch_check_output.return_value = b"1.1.1.1"
+        self.mock_check_output.return_value = b"1.1.1.1"
         service = Mock(status=Mock(loadBalancer=Mock(ingress=None)))
-        patch_get.return_value = service
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_get.return_value = service
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
@@ -746,42 +581,23 @@ class TestCharm(unittest.TestCase):
         relation_id = self.harness.add_relation(relation_name="fiveg-n2", remote_app="n2-requirer")
         self.harness.add_relation_unit(relation_id=relation_id, remote_unit_name="n2-requirer/0")
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.charm.unit.status, BlockedStatus("Waiting for MetalLB to be enabled")
-        )
+        assert self.harness.charm.unit.status == BlockedStatus("Waiting for MetalLB to be enabled")
 
-    # This one needs
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch("lightkube.core.client.Client.get")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_service_starts_running_after_n2_relation_joined_when_pebble_ready_then_n2_information_is_in_relation_databag(  # noqa: E501
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_check_output,
-        patch_get,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
         root = self.harness.get_filesystem_root("amf")
-        (root / "support/TLS/amf.pem").write_text(certificate)
+        (root / "support/TLS/amf.pem").write_text(CERTIFICATE)
         (root / "free5gc/config/amfcfg.conf").write_text(
             self._read_file("tests/unit/expected_config/config.conf").strip()
         )
@@ -791,14 +607,14 @@ class TestCharm(unittest.TestCase):
         relation_data = self.harness.get_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name
         )
-        self.assertEqual(relation_data, {})
-        patch_check_output.return_value = b"1.1.1.1"
+        assert relation_data == {}
+        self.mock_check_output.return_value = b"1.1.1.1"
         service = Mock(
             status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
         )
-        patch_get.return_value = service
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_get.return_value = service
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
@@ -810,40 +626,21 @@ class TestCharm(unittest.TestCase):
         relation_data = self.harness.get_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.app.name
         )
-        self.assertEqual(relation_data["amf_ip_address"], "1.1.1.1")
-        self.assertEqual(relation_data["amf_hostname"], "amf.pizza.com")
-        self.assertEqual(relation_data["amf_port"], "38412")
+        assert relation_data["amf_ip_address"] == "1.1.1.1"
+        assert relation_data["amf_hostname"] == "amf.pizza.com"
+        assert relation_data["amf_port"] == "38412"
 
-    # this is good
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch("lightkube.core.client.Client.get")
-    @patch("charm.generate_private_key")
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_more_than_one_n2_requirers_join_n2_relation_when_service_starts_then_n2_information_is_in_relation_databag(  # noqa: E501
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_check_output,
-        patch_generate_private_key,
-        patch_get,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
         certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
         root = self.harness.get_filesystem_root("amf")
@@ -851,15 +648,14 @@ class TestCharm(unittest.TestCase):
         (root / "free5gc/config/amfcfg.conf").write_text(
             self._read_file("tests/unit/expected_config/config.conf").strip()
         )
-        patch_check_output.return_value = b"1.1.1.1"
+        self.mock_check_output.return_value = b"1.1.1.1"
         service = Mock(
             status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", hostname="amf.pizza.com")]))
         )
-        patch_get.return_value = service
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
-        private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
+        self.mock_get.return_value = service
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
@@ -883,45 +679,30 @@ class TestCharm(unittest.TestCase):
         relation_data = self.harness.get_relation_data(
             relation_id=relation_2_id, app_or_unit=self.harness.charm.app.name
         )
-        self.assertEqual(relation_data["amf_ip_address"], "1.1.1.1")
-        self.assertEqual(relation_data["amf_hostname"], "amf.pizza.com")
-        self.assertEqual(relation_data["amf_port"], "38412")
+        assert relation_data["amf_ip_address"] == "1.1.1.1"
+        assert relation_data["amf_hostname"] == "amf.pizza.com"
+        assert relation_data["amf_port"] == "38412"
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
-    @patch("charm.check_output")
-    @patch("charm.generate_private_key")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_can_connect_when_on_pebble_ready_then_private_key_is_generated(
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_generate_private_key,
-        patch_check_output,
-        patch_generate_csr,
-        patch_get_assigned_certificates,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
         private_key = b"whatever key content"
-        patch_generate_private_key.return_value = private_key
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
         certificate = "Whatever certificate content"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_csr.return_value = CSR
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
         root = self.harness.get_filesystem_root("amf")
         (root / "support/TLS/amf.pem").write_text(certificate)
-        patch_check_output.return_value = b"1.1.1.1"
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_check_output.return_value = b"1.1.1.1"
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="nrf")
         self.harness.add_relation(
@@ -930,48 +711,41 @@ class TestCharm(unittest.TestCase):
         self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
         self.harness.evaluate_status()
-        self.assertEqual((root / "support/TLS/amf.key").read_text(), private_key.decode())
+        assert (root / "support/TLS/amf.key").read_text() == private_key.decode()
 
     def test_given_certificates_are_stored_when_on_certificates_relation_broken_then_certificates_are_removed(  # noqa: E501
-        self,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
-        private_key = b"whatever key content"
-        csr = b"Whatever CSR content"
         certificate = "Whatever certificate content"
         root = self.harness.get_filesystem_root("amf")
-        (root / "support/TLS/amf.key").write_text(private_key.decode())
-        (root / "support/TLS/amf.csr").write_text(csr.decode())
+        (root / "support/TLS/amf.key").write_text(PRIVATE_KEY.decode())
+        (root / "support/TLS/amf.csr").write_text(CSR.decode())
         (root / "support/TLS/amf.pem").write_text(certificate)
 
         self.harness.set_can_connect(container="amf", val=True)
 
         self.harness.charm._on_certificates_relation_broken(event=Mock)
 
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             (root / "support/TLS/amf.key").read_text()
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             (root / "support/TLS/amf.pem").read_text()
-        with self.assertRaises(FileNotFoundError):
+        with pytest.raises(FileNotFoundError):
             (root / "support/TLS/amf.csr").read_text()
 
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch("charms.data_platform_libs.v0.data_interfaces.DatabaseRequires.is_resource_created")
     def test_given_certificates_are_stored_when_on_certificates_relation_broken_then_status_is_blocked(  # noqa: E501
-        self,
-        patch_is_resource_created,
-        patch_nrf_url,
-        patch_check_output,
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        certificate = "Whatever certificate content"
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_generate_csr.return_value = CSR
         root = self.harness.get_filesystem_root("amf")
-        (root / "support/TLS/amf.pem").write_text(certificate)
-        patch_is_resource_created.return_value = True
-        patch_nrf_url.return_value = "http://nrf:8081"
-        patch_check_output.return_value = b"1.1.1.1"
+        (root / "support/TLS/amf.pem").write_text(CERTIFICATE)
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = "http://nrf:8081"
+        self.mock_check_output.return_value = b"1.1.1.1"
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="mongodb")
         cert_rel_id = self.harness.add_relation(
@@ -980,29 +754,16 @@ class TestCharm(unittest.TestCase):
         self._create_database_relation_and_populate_data()
         self.harness.remove_relation(cert_rel_id)
         self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.charm.unit.status, BlockedStatus("Waiting for certificates relation")
-        )
+        assert self.harness.charm.unit.status == BlockedStatus("Waiting for certificates relation")
 
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation",  # noqa: E501
-        new=Mock,
-    )
-    @patch("charm.generate_csr")
     def test_given_private_key_exists_when_pebble_ready_then_csr_is_generated(
-        self,
-        patch_generate_csr,
-        patch_nrf_url,
-        patch_check_output,
+        self
     ):
-        patch_check_output.return_value = b"1.1.1.1"
+        self.mock_check_output.return_value = b"1.1.1.1"
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        patch_nrf_url.return_value = "http://nrf:8081"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_nrf_url.return_value = "http://nrf:8081"
+        self.mock_generate_csr.return_value = CSR
         private_key = "private key content"
         root = self.harness.get_filesystem_root("amf")
         (root / "support/TLS/amf.key").write_text(private_key)
@@ -1015,30 +776,18 @@ class TestCharm(unittest.TestCase):
         self._create_database_relation_and_populate_data()
         self.harness.container_pebble_ready("amf")
 
-        self.assertEqual((root / "support/TLS/amf.csr").read_text(), csr.decode())
+        assert (root / "support/TLS/amf.csr").read_text() == CSR.decode()
 
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
     def test_given_private_key_exists_and_cert_not_yet_requested_when_pebble_ready_then_cert_is_requested(  # noqa: E501
-        self,
-        patch_generate_csr,
-        patch_request_certificate_creation,
-        patch_nrf_url,
-        patch_check_output,
+        self
     ):
-        patch_check_output.return_value = b"1.1.1.1"
+        self.mock_check_output.return_value = b"1.1.1.1"
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        patch_nrf_url.return_value = "http://nrf:8081"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
-        private_key = "private key content"
+        self.mock_nrf_url.return_value = "http://nrf:8081"
+        self.mock_generate_csr.return_value = CSR
         root = self.harness.get_filesystem_root("amf")
-        (root / "support/TLS/amf.key").write_text(private_key)
+        (root / "support/TLS/amf.key").write_text(PRIVATE_KEY.decode())
 
         self.harness.add_relation(relation_name="fiveg_nrf", remote_app="mongodb")
         self.harness.add_relation(
@@ -1048,38 +797,23 @@ class TestCharm(unittest.TestCase):
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.container_pebble_ready("amf")
 
-        patch_request_certificate_creation.assert_called_with(certificate_signing_request=csr)
+        self.mock_request_certificate_creation.assert_called_with(certificate_signing_request=CSR)
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation",  # noqa: E501
-    )
     def test_given_cert_already_stored_when_pebble_ready_then_cert_is_not_requested(  # noqa: E501
-        self,
-        patch_request_certificate_creation,
-        patch_nrf_url,
-        patch_check_output,
-        patch_get_assigned_certificates,
+        self
     ):
-        patch_check_output.return_value = b"1.1.1.1"
+        self.mock_check_output.return_value = b"1.1.1.1"
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        patch_nrf_url.return_value = "http://nrf:8081"
-        private_key = "whatever key content"
-        csr = b"Whatever CSR content"
-        certificate = "Whatever certificate content"
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         root = self.harness.get_filesystem_root("amf")
-        (root / "support/TLS/amf.key").write_text(private_key)
-        (root / "support/TLS/amf.pem").write_text(certificate)
-        (root / "support/TLS/amf.csr").write_text(csr.decode())
+        (root / "support/TLS/amf.key").write_text(PRIVATE_KEY.decode())
+        (root / "support/TLS/amf.pem").write_text(CERTIFICATE)
+        (root / "support/TLS/amf.csr").write_text(CSR.decode())
         provider_certificate = Mock(ProviderCertificate)
-        provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.certificate = CERTIFICATE
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
 
@@ -1091,34 +825,25 @@ class TestCharm(unittest.TestCase):
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.container_pebble_ready("amf")
 
-        patch_request_certificate_creation.assert_not_called()
+        self.mock_request_certificate_creation.assert_not_called()
 
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
     def test_given_csr_matches_stored_one_when_pebble_ready_then_certificate_is_pushed(
-        self,
-        patch_get_assigned_certificates,
-        patch_nrf_url,
-        patch_check_output,
+        self
     ):
-        patch_check_output.return_value = b"1.1.1.1"
+        self.mock_check_output.return_value = b"1.1.1.1"
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         private_key = "whatever key content"
-        csr = b"Whatever CSR content"
         root = self.harness.get_filesystem_root("amf")
         (root / "support/TLS/amf.key").write_text(private_key)
-        (root / "support/TLS/amf.csr").write_text(csr.decode())
+        (root / "support/TLS/amf.csr").write_text(CSR.decode())
         certificate = "Whatever certificate content"
         (root / "support/TLS/amf.pem").write_text(certificate)
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
 
@@ -1130,34 +855,25 @@ class TestCharm(unittest.TestCase):
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.container_pebble_ready("amf")
 
-        self.assertEqual((root / "support/TLS/amf.pem").read_text(), certificate)
+        assert (root / "support/TLS/amf.pem").read_text() == certificate
 
-    @patch("charm.check_output")
-    @patch("charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url", new_callable=PropertyMock)
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.get_assigned_certificates",  # noqa: E501
-    )
     def test_given_certificate_matches_stored_one_when_pebble_ready_then_certificate_is_not_pushed(
-        self,
-        patch_get_assigned_certificates,
-        patch_nrf_url,
-        patch_check_output,
+        self
     ):
-        patch_check_output.return_value = b"1.1.1.1"
+        self.mock_check_output.return_value = b"1.1.1.1"
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
-        patch_nrf_url.return_value = "http://nrf:8081"
+        self.mock_nrf_url.return_value = "http://nrf:8081"
         private_key = "whatever key content"
-        csr = b"Whatever CSR content"
         root = self.harness.get_filesystem_root("amf")
         (root / "support/TLS/amf.key").write_text(private_key)
-        (root / "support/TLS/amf.csr").write_text(csr.decode())
+        (root / "support/TLS/amf.csr").write_text(CSR.decode())
         certificate = "Whatever certificate content"
         (root / "support/TLS/amf.pem").write_text(certificate)
         provider_certificate = Mock(ProviderCertificate)
         provider_certificate.certificate = certificate
-        provider_certificate.csr = csr.decode()
-        patch_get_assigned_certificates.return_value = [
+        provider_certificate.csr = CSR.decode()
+        self.mock_get_assigned_certificates.return_value = [
             provider_certificate,
         ]
 
@@ -1169,14 +885,10 @@ class TestCharm(unittest.TestCase):
         self.harness.set_can_connect(container="amf", val=True)
         self.harness.container_pebble_ready("amf")
 
-        self.assertEqual((root / "support/TLS/amf.pem").read_text(), certificate)
+        assert (root / "support/TLS/amf.pem").read_text() == certificate
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
     def test_given_certificate_does_not_match_stored_one_when_certificate_expiring_then_certificate_is_not_requested(  # noqa: E501
-        self, patch_generate_csr, patch_request_certificate_creation
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         event = Mock()
@@ -1184,20 +896,15 @@ class TestCharm(unittest.TestCase):
         certificate = "Stored certificate content"
         (root / "support/TLS/amf.pem").write_text(certificate)
         event.certificate = "Relation certificate content (different from stored)"
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_csr.return_value = CSR
         self.harness.set_can_connect(container="amf", val=True)
 
         self.harness.charm._on_certificate_expiring(event=event)
 
-        patch_request_certificate_creation.assert_not_called()
+        self.mock_request_certificate_creation.assert_not_called()
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
     def test_given_amf_cannot_connect_when_certificate_expiring_then_certificate_is_not_requested(  # noqa: E501
-        self, patch_generate_csr, patch_request_certificate_creation
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         event = Mock()
@@ -1205,20 +912,15 @@ class TestCharm(unittest.TestCase):
         certificate = "Stored certificate content"
         (root / "support/TLS/amf.pem").write_text(certificate)
         event.certificate = certificate
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_csr.return_value = CSR
         self.harness.set_can_connect(container="amf", val=False)
 
         self.harness.charm._on_certificate_expiring(event=event)
 
-        patch_request_certificate_creation.assert_not_called()
+        self.mock_request_certificate_creation.assert_not_called()
 
-    @patch(
-        "charms.tls_certificates_interface.v3.tls_certificates.TLSCertificatesRequiresV3.request_certificate_creation",  # noqa: E501
-    )
-    @patch("charm.generate_csr")
     def test_given_certificate_matches_stored_one_when_certificate_expiring_then_certificate_is_requested(  # noqa: E501
-        self, patch_generate_csr, patch_request_certificate_creation
+        self
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         root = self.harness.get_filesystem_root("amf")
@@ -1228,17 +930,14 @@ class TestCharm(unittest.TestCase):
         (root / "support/TLS/amf.pem").write_text(certificate)
         event = Mock()
         event.certificate = certificate
-        csr = b"whatever csr content"
-        patch_generate_csr.return_value = csr
+        self.mock_generate_csr.return_value = CSR
         self.harness.set_can_connect(container="amf", val=True)
 
         self.harness.charm._on_certificate_expiring(event=event)
 
-        patch_request_certificate_creation.assert_called_with(certificate_signing_request=csr)
+        self.mock_request_certificate_creation.assert_called_with(certificate_signing_request=CSR)
 
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch("lightkube.core.client.Client.apply")
-    def test_when_install_then_external_service_is_created(self, patch_create):
+    def test_when_install_then_external_service_is_created(self):
         self.harness.charm.on.install.emit()
 
         calls = [
@@ -1247,7 +946,7 @@ class TestCharm(unittest.TestCase):
                     apiVersion="v1",
                     kind="Service",
                     metadata=ObjectMeta(
-                        namespace=self.namespace,
+                        namespace=NAMESPACE,
                         name=f"{self.harness.charm.app.name}-external",
                     ),
                     spec=ServiceSpec(
@@ -1266,19 +965,17 @@ class TestCharm(unittest.TestCase):
             ),
         ]
 
-        patch_create.assert_has_calls(calls=calls)
+        self.mock_apply.assert_has_calls(calls=calls)
 
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
-    @patch("lightkube.core.client.Client.delete")
-    def test_when_remove_then_external_service_is_deleted(self, patch_delete):
+    def test_when_remove_then_external_service_is_deleted(self):
         self.harness.charm.on.remove.emit()
 
         calls = [
             call(
                 Service,
-                namespace=self.namespace,
+                namespace=NAMESPACE,
                 name=f"{self.harness.charm.app.name}-external",
             ),
         ]
 
-        patch_delete.assert_has_calls(calls=calls)
+        self.mock_delete.assert_has_calls(calls=calls)


### PR DESCRIPTION
# Description

This PR aims to remove `unittest` framework in favor of `pytest`, as described [here](https://juju.is/docs/sdk/write-a-unit-test-for-a-charm).
Main changes:
* Use fixtures to configure harness and patches
* Use fixtures to create `database`, `fiveg_nrf`, `certificates` relations

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [X] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library