### PR TITLE
feat: Implement the requirer side of `sdcore-config` interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,12 +16,14 @@ juju deploy mongodb-k8s --trust --channel=6/beta
 juju deploy sdcore-nrf-k8s --channel=edge
 juju deploy self-signed-certificates --channel=stable
 juju deploy sdcore-webui-k8s --channel=1.5/edge
-juju integrate sdcore-nrf-k8s:database mongodb-k8s
+juju integrate sdcore-webui-k8s:common_database mongodb-k8s:database
+juju integrate sdcore-webui-k8s:auth_database mongodb-k8s:database
+juju integrate sdcore-nrf-k8s:database mongodb-k8s:database
 juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
-juju integrate sdcore-amf-k8s:database mongodb-k8s
+juju integrate sdcore-amf-k8s:database mongodb-k8s:database
 juju integrate sdcore-amf-k8s:fiveg_nrf sdcore-nrf-k8s:fiveg_nrf
 juju integrate sdcore-amf-k8s:certificates self-signed-certificates:certificates
-juju integrate sdcore-amf-k8s:sdcore-config sdcore-webui-k8s:sdcore-config
+juju integrate sdcore-amf-k8s:sdcore_config sdcore-webui-k8s:sdcore-config
 ```
 
 ### Overriding external access information for N2 interface

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ juju deploy sdcore-amf-k8s --trust --channel=edge
 juju deploy mongodb-k8s --trust --channel=6/beta
 juju deploy sdcore-nrf-k8s --channel=edge
 juju deploy self-signed-certificates --channel=stable
+juju deploy sdcore-webui-k8s --channel=1.5/edge
 juju integrate sdcore-nrf-k8s:database mongodb-k8s
 juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-amf-k8s:database mongodb-k8s
 juju integrate sdcore-amf-k8s:fiveg_nrf sdcore-nrf-k8s:fiveg_nrf
 juju integrate sdcore-amf-k8s:certificates self-signed-certificates:certificates
+juju integrate sdcore-amf-k8s:sdcore-config sdcore-webui-k8s:sdcore-config
 ```
 
 ### Overriding external access information for N2 interface

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -49,7 +49,7 @@ requires:
     interface: tls-certificates
   logging:
     interface: loki_push_api
-  sdcore-config:
+  sdcore_config:
     interface: sdcore_config
 
 type: charm

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -49,6 +49,8 @@ requires:
     interface: tls-certificates
   logging:
     interface: loki_push_api
+  sdcore-config:
+    interface: sdcore_config
 
 type: charm
 bases:

--- a/lib/charms/sdcore_webui_k8s/v0/sdcore_config.py
+++ b/lib/charms/sdcore_webui_k8s/v0/sdcore_config.py
@@ -1,0 +1,339 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+"""Library for the `sdcore_config` relation.
+
+This library contains the Requires and Provides classes for handling the `sdcore_config`
+interface.
+
+The purpose of this library is to relate charms claiming
+to be able to provide or consume the information to access the webui GRPC address
+for configuration purposes in SD-Core.
+
+## Getting Started
+From a charm directory, fetch the library using `charmcraft`:
+
+```shell
+charmcraft fetch-lib charms.sdcore_webui_k8s.v0.sdcore_config
+```
+
+Add the following libraries to the charm's `requirements.txt` file:
+- pydantic
+- pytest-interface-tester
+
+### Requirer charm
+The requirer charm is the one requiring the Webui information.
+
+Example:
+```python
+
+import logging
+
+from ops.charm import CharmBase
+from ops.main import main
+
+from lib.charms.sdcore_webui_k8s.v0.sdcore_config import (
+    SdcoreConfigRequires,
+    WebuiBroken,
+    WebuiUrlAvailable,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DummySdcoreConfigRequirerCharm(CharmBase):
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.webui_requirer = SdcoreConfigRequires(
+            self, "sdcore_config"
+        )
+        self.framework.observe(
+            self.webui_requirer.on.webui_url_available,
+            self._on_webui_url_available
+        )
+        self.framework.observe(self.webui_requirer.on.webui_broken, self._on_webui_broken)
+
+    def _on_webui_url_available(self, event: WebuiUrlAvailable):
+        logging.info(f"Webui URL from the event: {event.webui_url}")
+        logging.info(f"Webui URL from the property: {self.webui_requirer.webui_url}")
+
+    def _on_webui_broken(self, event: WebuiBroken) -> None:
+        logging.info(f"Received {event}")
+
+
+if __name__ == "__main__":
+    main(DummySdcoreConfigRequirerCharm)
+```
+
+### Provider charm
+The provider charm is the one providing the information about the Webui.
+
+Example:
+```python
+
+from ops.charm import CharmBase, RelationJoinedEvent
+from ops.main import main
+
+from lib.charms.sdcore_webui_k8s.v0.sdcore_config import SdcoreConfigProvides
+
+
+class DummySdcoreConfigProviderCharm(CharmBase):
+
+    WEBUI_URL = "sdcore-webui-k8s:9876"
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.webui_url_provider = SdcoreConfigProvides(self, "sdcore_config")
+        self.framework.observe(
+            self.on.sdcore_config_relation_joined, self._on_sdcore_config_relation_joined
+        )
+
+    def _on_sdcore_config_relation_joined(self, event: RelationJoinedEvent):
+        relation_id = event.relation.id
+        self.webui_url_provider.set_webui_url(
+            webui_url=self.WEBUI_URL,
+            relation_id=relation_id,
+        )
+
+
+if __name__ == "__main__":
+    main(DummySdcoreConfigProviderCharm)
+```
+
+"""
+import logging
+from typing import Optional
+
+from interface_tester.schema_base import DataBagSchema  # type: ignore[import]
+from ops.charm import CharmBase, CharmEvents, RelationBrokenEvent, RelationChangedEvent
+from ops.framework import EventBase, EventSource, Handle, Object
+from ops.model import Relation
+from pydantic import BaseModel, Field, ValidationError
+
+# The unique Charmhub library identifier, never change it
+LIBID = "e2f454cc121f449bbaa8fb0fd5a9867b"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH = 1
+
+logger = logging.getLogger(__name__)
+
+"""Schemas definition for the provider and requirer sides of the `sdcore_config` interface.
+It exposes two interfaces.schema_base.DataBagSchema subclasses called:
+- ProviderSchema
+- RequirerSchema
+Examples:
+    ProviderSchema:
+        unit: <empty>
+        app: {
+            "webui_url": "sdcore-webui-k8s:9876",
+        }
+    RequirerSchema:
+        unit: <empty>
+        app:  <empty>
+"""
+
+
+class SdcoreConfigProviderAppData(BaseModel):
+    """Provider application data for sdcore_config."""
+    webui_url: str = Field(
+        description="GRPC address of the Webui including Webui hostname and a fixed GRPC port.",
+        examples=["sdcore-webui-k8s:9876"]
+    )
+
+
+class ProviderSchema(DataBagSchema):
+    """The schema for the provider side of the sdcore-config interface."""
+    app: SdcoreConfigProviderAppData
+
+
+def data_is_valid(data: dict) -> bool:
+    """Return whether data is valid.
+
+    Args:
+        data (dict): Data to be validated.
+
+    Returns:
+        bool: True if data is valid, False otherwise.
+    """
+    try:
+        ProviderSchema(app=data)
+        return True
+    except ValidationError as e:
+        logger.error("Invalid data: %s", e)
+        return False
+
+
+class WebuiUrlAvailable(EventBase):
+    """Charm event emitted when the Webui URL is available."""
+
+    def __init__(self, handle: Handle, webui_url: str):
+        """Init."""
+        super().__init__(handle)
+        self.webui_url = webui_url
+
+    def snapshot(self) -> dict:
+        """Return snapshot."""
+        return {
+            "webui_url": self.webui_url,
+        }
+
+    def restore(self, snapshot: dict) -> None:
+        """Restore snapshot."""
+        self.webui_url = snapshot["webui_url"]
+
+
+class WebuiBroken(EventBase):
+    """Charm event emitted when the Webui goes down."""
+
+    def __init__(self, handle: Handle):
+        """Init."""
+        super().__init__(handle)
+
+
+class SdcoreConfigRequirerCharmEvents(CharmEvents):
+    """List of events that the SD-Core config requirer charm can leverage."""
+
+    webui_url_available = EventSource(WebuiUrlAvailable)
+    webui_broken = EventSource(WebuiBroken)
+
+
+class SdcoreConfigRequires(Object):
+    """Class to be instantiated by the SD-Core config requirer charm."""
+
+    on = SdcoreConfigRequirerCharmEvents()
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Init."""
+        super().__init__(charm, relation_name)
+        self.charm = charm
+        self.relation_name = relation_name
+        self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
+        self.framework.observe(charm.on[relation_name].relation_broken, self._on_relation_broken)
+
+    def _on_relation_changed(self, event: RelationChangedEvent) -> None:
+        """Handle relation changed event.
+
+        Args:
+            event (RelationChangedEvent): Juju event.
+
+        Returns:
+            None
+        """
+        if remote_app_relation_data := self._get_remote_app_relation_data(event.relation):
+            self.on.webui_url_available.emit(
+                webui_url=remote_app_relation_data,
+            )
+
+    def _on_relation_broken(self, event: RelationBrokenEvent) -> None:
+        """Handle the Sdcore config relation broken event.
+
+        Args:
+            event (RelationBrokenEvent): Juju event.
+        """
+        self.on.webui_broken.emit()
+
+    @property
+    def webui_url(self) -> Optional[str]:
+        """Return the address of the webui GRPC endpoint.
+
+        Returns:
+            str: Endpoint address.
+        """
+        return self._get_remote_app_relation_data()
+
+    def _get_remote_app_relation_data(
+        self, relation: Optional[Relation] = None
+    ) -> Optional[str]:
+        """Get relation data for the remote application.
+
+        Args:
+            relation: Juju relation object (optional).
+
+        Returns:
+        str: Relation data for the remote application
+            or None if the relation data is invalid.
+        """
+        relation = relation or self.model.get_relation(self.relation_name)
+
+        if not relation:
+            logger.error("No relation: %s", self.relation_name)
+            return None
+
+        if not relation.app:
+            logger.warning("No remote application in relation: %s", self.relation_name)
+            return None
+
+        remote_app_relation_data = dict(relation.data[relation.app])
+
+        if not data_is_valid(remote_app_relation_data):
+            logger.error("Invalid relation data: %s", remote_app_relation_data)
+            return None
+
+        return remote_app_relation_data["webui_url"]
+
+
+class SdcoreConfigProvides(Object):
+    """Class to be instantiated by the charm providing the SD-Core Webui URL."""
+
+    def __init__(self, charm: CharmBase, relation_name: str):
+        """Init."""
+        super().__init__(charm, relation_name)
+        self.relation_name = relation_name
+        self.charm = charm
+
+    def set_webui_url(self, webui_url: str, relation_id: int) -> None:
+        """Set the address of the Webui GRPC endpoint.
+
+        Args:
+            webui_url (str): Webui GRPC service address.
+            relation_id (int): Relation ID.
+
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            raise RuntimeError("Unit must be leader to set application relation data.")
+
+        if not data_is_valid(data={"webui_url": webui_url}):
+            raise ValueError(f"Invalid url: {webui_url}")
+
+        relation = self.model.get_relation(
+            relation_name=self.relation_name, relation_id=relation_id
+        )
+
+        if not relation:
+            raise RuntimeError(f"Relation {self.relation_name} not created yet.")
+
+        if relation not in self.model.relations[self.relation_name]:
+            raise RuntimeError(f"Relation {self.relation_name} not created yet.")
+
+        relation.data[self.charm.app].update({"webui_url": webui_url})
+
+    def set_webui_url_in_all_relations(self, webui_url: str) -> None:
+        """Set Webui URL in applications for all applications.
+
+        Args:
+            webui_url (str): Webui GRPC service address
+        Returns:
+            None
+        """
+        if not self.charm.unit.is_leader():
+            raise RuntimeError("Unit must be leader to set application relation data.")
+
+        if not data_is_valid(data={"webui_url": webui_url}):
+            raise ValueError(f"Invalid url: {webui_url}")
+
+        relations = self.model.relations[self.relation_name]
+
+        if not relations:
+            raise RuntimeError(f"Relation {self.relation_name} not created yet.")
+
+        for relation in relations:
+            relation.data[self.charm.app].update({"webui_url": webui_url})

--- a/src/charm.py
+++ b/src/charm.py
@@ -122,9 +122,9 @@ class AMFOperatorCharm(CharmBase):
             self._webui_requires.on.webui_url_available,
             self._configure_amf
         )
-        self.framework.observe(self.on.sdcore_config_relation_joined, self._configure_amf)
         self.framework.observe(self.on.fiveg_n2_relation_joined, self._on_n2_relation_joined)
         self.framework.observe(self.on.certificates_relation_joined, self._configure_amf)
+        self.framework.observe(self.on.sdcore_config_relation_joined, self._configure_amf)
         self.framework.observe(
             self.on.certificates_relation_broken, self._on_certificates_relation_broken
         )

--- a/src/charm.py
+++ b/src/charm.py
@@ -16,6 +16,9 @@ from charms.prometheus_k8s.v0.prometheus_scrape import (  # type: ignore[import]
 )
 from charms.sdcore_amf_k8s.v0.fiveg_n2 import N2Provides  # type: ignore[import]
 from charms.sdcore_nrf_k8s.v0.fiveg_nrf import NRFRequires  # type: ignore[import]
+from charms.sdcore_webui_k8s.v0.sdcore_config import (  # type: ignore[import]
+    SdcoreConfigRequires,
+)
 from charms.tls_certificates_interface.v3.tls_certificates import (  # type: ignore[import]
     CertificateExpiringEvent,
     TLSCertificatesRequiresV3,
@@ -46,10 +49,6 @@ from ops.charm import (
 from ops.main import main
 from ops.pebble import Layer
 
-from charms.sdcore_webui_k8s.v0.sdcore_config import (
-    SdcoreConfigRequires,
-)
-
 logger = logging.getLogger(__name__)
 
 PROMETHEUS_PORT = 9089
@@ -71,7 +70,7 @@ CORE_NETWORK_SHORT_NAME = "SDCORE"
 N2_RELATION_NAME = "fiveg-n2"
 LOGGING_RELATION_NAME = "logging"
 FIVEG_NRF_RELATION_NAME = "fiveg_nrf"
-SDCORE_CONFIG_RELATION_NAME = "sdcore-config"
+SDCORE_CONFIG_RELATION_NAME = "sdcore_config"
 TLS_RELATION_NAME = "certificates"
 
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -258,6 +258,13 @@ class AMFOperatorCharm(CharmBase):
         event.add_status(ActiveStatus())
 
     def _relation_not_created(self) -> Optional[str]:
+        """Return name of not created relation.
+
+        If all the relations are created, it returns None.
+
+        Returns:
+            str: The relation name.
+        """
         for relation in [
             FIVEG_NRF_RELATION_NAME,
             DATABASE_RELATION_NAME,

--- a/src/templates/amfcfg.conf.j2
+++ b/src/templates/amfcfg.conf.j2
@@ -1,6 +1,7 @@
 configuration:
   amfDBName: {{ database_name }}
   amfName: AMF
+  webuiUri: {{ webui_uri }}
   debugProfilePort: 5001
   enableDBStore: false
   enableSctpLb: false

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -20,13 +20,14 @@ NRF_CHARM_NAME = "sdcore-nrf-k8s"
 NRF_CHARM_CHANNEL = "1.5/edge"
 TLS_PROVIDER_CHARM_NAME = "self-signed-certificates"
 TLS_PROVIDER_CHARM_CHANNEL = "latest/stable"
+WEBUI_CHARM_NAME = "sdcore-webui-k8s"
+WEBUI_CHARM_CHANNEL = "1.5/edge"
 GRAFANA_AGENT_CHARM_NAME = "grafana-agent-k8s"
 GRAFANA_AGENT_CHARM_CHANNEL = "latest/stable"
 TIMEOUT = 15 * 60
 
 
 @pytest.fixture(scope="module")
-@pytest.mark.abort_on_fail
 async def deploy(ops_test: OpsTest, request):
     """Deploy the charm-under-test."""
     assert ops_test.model
@@ -43,6 +44,7 @@ async def deploy(ops_test: OpsTest, request):
     await _deploy_mongodb(ops_test)
     await _deploy_nrf(ops_test)
     await _deploy_self_signed_certificates(ops_test)
+    await _deploy_webui(ops_test)
     await _deploy_grafana_agent(ops_test)
 
 
@@ -65,6 +67,7 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, deploy):
     await ops_test.model.integrate(relation1=NRF_CHARM_NAME, relation2=TLS_PROVIDER_CHARM_NAME)
     await ops_test.model.integrate(relation1=f"{APP_NAME}:database", relation2=f"{DB_CHARM_NAME}")
     await ops_test.model.integrate(relation1=APP_NAME, relation2=NRF_CHARM_NAME)
+    await ops_test.model.integrate(relation1=f"{APP_NAME}:sdcore-config", relation2=f"{WEBUI_CHARM_NAME}:sdcore-config")
     await ops_test.model.integrate(relation1=APP_NAME, relation2=TLS_PROVIDER_CHARM_NAME)
     await ops_test.model.integrate(
         relation1=f"{APP_NAME}:logging", relation2=GRAFANA_AGENT_CHARM_NAME
@@ -131,6 +134,21 @@ async def test_restore_database_and_wait_for_active_status(ops_test: OpsTest, de
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)
 
 
+@pytest.mark.abort_on_fail
+async def test_remove_webui_and_wait_for_blocked_status(ops_test: OpsTest, deploy):
+    assert ops_test.model
+    await ops_test.model.remove_application(WEBUI_CHARM_NAME, block_until_done=True)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="blocked", timeout=TIMEOUT)
+
+
+@pytest.mark.abort_on_fail
+async def test_restore_webui_and_wait_for_active_status(ops_test: OpsTest, deploy):
+    assert ops_test.model
+    await _deploy_webui(ops_test)
+    await ops_test.model.integrate(relation1=APP_NAME, relation2=WEBUI_CHARM_NAME)
+    await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)
+
+
 async def _deploy_mongodb(ops_test: OpsTest):
     assert ops_test.model
     await ops_test.model.deploy(
@@ -164,4 +182,13 @@ async def _deploy_nrf(ops_test: OpsTest):
         NRF_CHARM_NAME,
         application_name=NRF_CHARM_NAME,
         channel=NRF_CHARM_CHANNEL,
+    )
+
+
+async def _deploy_webui(ops_test: OpsTest):
+    assert ops_test.model
+    await ops_test.model.deploy(
+        WEBUI_CHARM_NAME,
+        application_name=WEBUI_CHARM_NAME,
+        channel=WEBUI_CHARM_CHANNEL,
     )

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -66,8 +66,16 @@ async def test_relate_and_wait_for_active_status(ops_test: OpsTest, deploy):
     )
     await ops_test.model.integrate(relation1=NRF_CHARM_NAME, relation2=TLS_PROVIDER_CHARM_NAME)
     await ops_test.model.integrate(relation1=f"{APP_NAME}:database", relation2=f"{DB_CHARM_NAME}")
+    await ops_test.model.integrate(
+        relation1=f"{WEBUI_CHARM_NAME}:common_database", relation2=f"{DB_CHARM_NAME}"
+    )
+    await ops_test.model.integrate(
+        relation1=f"{WEBUI_CHARM_NAME}:auth_database", relation2=f"{DB_CHARM_NAME}"
+    )
     await ops_test.model.integrate(relation1=APP_NAME, relation2=NRF_CHARM_NAME)
-    await ops_test.model.integrate(relation1=f"{APP_NAME}:sdcore-config", relation2=f"{WEBUI_CHARM_NAME}:sdcore-config")
+    await ops_test.model.integrate(
+        relation1=f"{APP_NAME}:sdcore_config", relation2=f"{WEBUI_CHARM_NAME}:sdcore-config"
+    )
     await ops_test.model.integrate(relation1=APP_NAME, relation2=TLS_PROVIDER_CHARM_NAME)
     await ops_test.model.integrate(
         relation1=f"{APP_NAME}:logging", relation2=GRAFANA_AGENT_CHARM_NAME
@@ -145,7 +153,15 @@ async def test_remove_webui_and_wait_for_blocked_status(ops_test: OpsTest, deplo
 async def test_restore_webui_and_wait_for_active_status(ops_test: OpsTest, deploy):
     assert ops_test.model
     await _deploy_webui(ops_test)
-    await ops_test.model.integrate(relation1=APP_NAME, relation2=WEBUI_CHARM_NAME)
+    await ops_test.model.integrate(
+        relation1=f"{WEBUI_CHARM_NAME}:common_database", relation2=f"{DB_CHARM_NAME}"
+    )
+    await ops_test.model.integrate(
+        relation1=f"{WEBUI_CHARM_NAME}:auth_database", relation2=f"{DB_CHARM_NAME}"
+    )
+    await ops_test.model.integrate(
+        relation1=f"{APP_NAME}:sdcore_config", relation2=f"{WEBUI_CHARM_NAME}:sdcore-config"
+    )
     await ops_test.model.wait_for_idle(apps=[APP_NAME], status="active", timeout=TIMEOUT)
 
 

--- a/tests/unit/expected_config/config.conf
+++ b/tests/unit/expected_config/config.conf
@@ -1,6 +1,7 @@
 configuration:
   amfDBName: sdcore_amf
   amfName: AMF
+  webuiUri: sdcore-webui:9876
   debugProfilePort: 5001
   enableDBStore: false
   enableSctpLb: false

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -144,30 +144,32 @@ class TestCharm:
         return content
 
     def test_given_fiveg_nrf_relation_not_created_when_pebble_ready_then_status_is_blocked(
-        self
+        self, certificates_relation_id, sdcore_config_relation_id, database_relation_id
     ):
         self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
         self.harness.add_relation(relation_name=DB_RELATION_NAME, remote_app=DB_APPLICATION_NAME)
         self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
-        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation")
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation(s)")
 
     def test_given_database_relation_not_created_when_pebble_ready_then_status_is_blocked(
-        self, nrf_relation_id
+        self, nrf_relation_id, sdcore_config_relation_id, certificates_relation_id
     ):
         self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
         self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
-        assert self.harness.model.unit.status == BlockedStatus("Waiting for database relation")
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for database relation(s)")
 
     def test_given_certificates_relation_not_created_when_pebble_ready_then_status_is_blocked(
-        self, nrf_relation_id
+        self, nrf_relation_id, sdcore_config_relation_id
     ):
         self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
         self.harness.add_relation(relation_name=DB_RELATION_NAME, remote_app=DB_APPLICATION_NAME)
         self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
-        assert self.harness.model.unit.status == BlockedStatus("Waiting for certificates relation")
+        assert self.harness.model.unit.status == BlockedStatus(
+            "Waiting for certificates relation(s)"
+        )
 
     def test_given_sdcore_config_relation_not_created_when_pebble_ready_then_status_is_blocked(
         self, nrf_relation_id, certificates_relation_id
@@ -177,11 +179,15 @@ class TestCharm:
         self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
         assert self.harness.model.unit.status == BlockedStatus(
-            "Waiting for sdcore_config relation"
+            "Waiting for sdcore_config relation(s)"
         )
 
     def test_given_amf_charm_in_active_state_when_nrf_relation_breaks_then_status_is_blocked(
-        self, database_relation_id, nrf_relation_id, sdcore_config_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.mock_check_output.return_value = b"1.1.1.1"
         self.mock_is_resource_created.return_value = True
@@ -192,10 +198,14 @@ class TestCharm:
         self.harness.remove_relation(nrf_relation_id)
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation")
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for fiveg_nrf relation(s)")
 
     def test_given_amf_charm_in_active_state_when_database_relation_breaks_then_status_is_blocked(
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.mock_check_output.return_value = b"1.1.1.1"
@@ -206,7 +216,7 @@ class TestCharm:
 
         self.harness.remove_relation(database_relation_id)
         self.harness.evaluate_status()
-        assert self.harness.model.unit.status == BlockedStatus("Waiting for database relation")
+        assert self.harness.model.unit.status == BlockedStatus("Waiting for database relation(s)")
 
     def test_given_amf_charm_in_active_state_when_sdcore_config_relation_breaks_then_status_is_blocked(  # noqa: E501
         self,
@@ -225,7 +235,7 @@ class TestCharm:
         self.harness.evaluate_status()
 
         assert self.harness.model.unit.status == BlockedStatus(
-            "Waiting for sdcore_config relation"
+            "Waiting for sdcore_config relation(s)"
         )
 
     def test_given_relations_created_and_database_not_available_when_pebble_ready_then_status_is_waiting(  # noqa: E501
@@ -819,7 +829,9 @@ class TestCharm:
         self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
         self.harness.remove_relation(certificates_relation_id)
         self.harness.evaluate_status()
-        assert self.harness.charm.unit.status == BlockedStatus("Waiting for certificates relation")
+        assert self.harness.charm.unit.status == BlockedStatus(
+            "Waiting for certificates relation(s)"
+        )
 
     def test_given_private_key_exists_when_pebble_ready_then_csr_is_generated(
         self,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -19,7 +19,7 @@ NRF_APPLICATION_NAME = "nrf"
 NRF_RELATION_NAME = "fiveg_nrf"
 NRF_URL = "http://nrf:8081"
 WEBUI_URL = "sdcore-webui:9876"
-SDCORE_CONFIG_RELATION_NAME = "sdcore-config"
+SDCORE_CONFIG_RELATION_NAME = "sdcore_config"
 WEBUI_APPLICATION_NAME = "sdcore-webui-operator"
 TLS_APPLICATION_NAME = "tls-certificates-operator"
 TLS_RELATION_NAME = "certificates"
@@ -177,7 +177,7 @@ class TestCharm:
         self.harness.container_pebble_ready(CONTAINER_NAME)
         self.harness.evaluate_status()
         assert self.harness.model.unit.status == BlockedStatus(
-            "Waiting for sdcore-config relation"
+            "Waiting for sdcore_config relation"
         )
 
     def test_given_amf_charm_in_active_state_when_nrf_relation_breaks_then_status_is_blocked(
@@ -225,7 +225,7 @@ class TestCharm:
         self.harness.evaluate_status()
 
         assert self.harness.model.unit.status == BlockedStatus(
-            "Waiting for sdcore-config relation"
+            "Waiting for sdcore_config relation"
         )
 
     def test_given_relations_created_and_database_not_available_when_pebble_ready_then_status_is_waiting(  # noqa: E501

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -18,6 +18,9 @@ DB_RELATION_NAME = "database"
 NRF_APPLICATION_NAME = "nrf"
 NRF_RELATION_NAME = "fiveg_nrf"
 NRF_URL = "http://nrf:8081"
+WEBUI_URL = "sdcore-webui:9876"
+SDCORE_CONFIG_RELATION_NAME = "sdcore-config"
+WEBUI_APPLICATION_NAME = "sdcore-webui-operator"
 TLS_APPLICATION_NAME = "tls-certificates-operator"
 TLS_RELATION_NAME = "certificates"
 NAMESPACE = "whatever"
@@ -30,6 +33,10 @@ class TestCharm:
     patcher_check_output = patch("charm.check_output")
     patcher_nrf_url = patch(
         "charms.sdcore_nrf_k8s.v0.fiveg_nrf.NRFRequires.nrf_url",
+        new_callable=PropertyMock
+    )
+    patcher_webui_url = patch(
+        "charms.sdcore_webui_k8s.v0.sdcore_config.SdcoreConfigRequires.webui_url",
         new_callable=PropertyMock
     )
     patcher_is_resource_created = patch(
@@ -52,6 +59,7 @@ class TestCharm:
         self.mock_request_certificate_creation = TestCharm.patcher_request_certificate_creation.start()  # noqa: E501
         self.mock_is_resource_created = TestCharm.patcher_is_resource_created.start()
         self.mock_nrf_url = TestCharm.patcher_nrf_url.start()
+        self.mock_webui_url = TestCharm.patcher_webui_url.start()
         self.mock_check_output = TestCharm.patcher_check_output.start()
         TestCharm.patcher_client.start()
         self.mock_get = TestCharm.patcher_get.start()
@@ -103,6 +111,24 @@ class TestCharm:
             remote_app=TLS_APPLICATION_NAME,
         )
 
+    @pytest.fixture()
+    def sdcore_config_relation_id(self) -> int:
+        sdcore_config_relation_id = self.harness.add_relation(
+            relation_name=SDCORE_CONFIG_RELATION_NAME,
+            remote_app=WEBUI_APPLICATION_NAME,
+        )
+        self.harness.add_relation_unit(
+            relation_id=sdcore_config_relation_id, remote_unit_name=f"{WEBUI_APPLICATION_NAME}/0"
+        )
+        self.harness.update_relation_data(
+            relation_id=sdcore_config_relation_id,
+            app_or_unit=WEBUI_APPLICATION_NAME,
+            key_values={
+                "webui_url": WEBUI_URL,
+            },
+        )
+        yield sdcore_config_relation_id
+
     @staticmethod
     def _read_file(path: str) -> str:
         """Read a file and returns as a string.
@@ -143,8 +169,19 @@ class TestCharm:
         self.harness.evaluate_status()
         assert self.harness.model.unit.status == BlockedStatus("Waiting for certificates relation")
 
+    def test_given_sdcore_config_relation_not_created_when_pebble_ready_then_status_is_blocked(
+        self, nrf_relation_id, certificates_relation_id
+    ):
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+        self.harness.add_relation(relation_name=DB_RELATION_NAME, remote_app=DB_APPLICATION_NAME)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
+        self.harness.evaluate_status()
+        assert self.harness.model.unit.status == BlockedStatus(
+            "Waiting for sdcore-config relation"
+        )
+
     def test_given_amf_charm_in_active_state_when_nrf_relation_breaks_then_status_is_blocked(
-        self, database_relation_id, nrf_relation_id
+        self, database_relation_id, nrf_relation_id, sdcore_config_relation_id
     ):
         self.mock_check_output.return_value = b"1.1.1.1"
         self.mock_is_resource_created.return_value = True
@@ -171,8 +208,28 @@ class TestCharm:
         self.harness.evaluate_status()
         assert self.harness.model.unit.status == BlockedStatus("Waiting for database relation")
 
+    def test_given_amf_charm_in_active_state_when_sdcore_config_relation_breaks_then_status_is_blocked(  # noqa: E501
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
+    ):
+        self.mock_check_output.return_value = b"1.1.1.1"
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = NRF_URL
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
+
+        self.harness.remove_relation(sdcore_config_relation_id)
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == BlockedStatus(
+            "Waiting for sdcore-config relation"
+        )
+
     def test_given_relations_created_and_database_not_available_when_pebble_ready_then_status_is_waiting(  # noqa: E501
-        self, nrf_relation_id, certificates_relation_id
+        self, nrf_relation_id, certificates_relation_id, sdcore_config_relation_id
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.mock_generate_private_key.return_value = PRIVATE_KEY
@@ -184,7 +241,7 @@ class TestCharm:
         assert self.harness.model.unit.status == WaitingStatus("Waiting for the amf database to be available")  # noqa: E501
 
     def test_given_database_info_not_available_when_pebble_ready_then_status_is_waiting(
-        self, nrf_relation_id, certificates_relation_id
+        self, nrf_relation_id, certificates_relation_id, sdcore_config_relation_id
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.mock_generate_private_key.return_value = PRIVATE_KEY
@@ -196,7 +253,11 @@ class TestCharm:
         assert self.harness.model.unit.status == WaitingStatus("Waiting for AMF database info to be available")  # noqa: E501
 
     def test_given_nrf_data_not_available_when_pebble_ready_then_status_is_waiting(
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.mock_generate_private_key.return_value = PRIVATE_KEY
@@ -207,8 +268,30 @@ class TestCharm:
         self.harness.evaluate_status()
         assert self.harness.model.unit.status == WaitingStatus("Waiting for NRF data to be available")  # noqa: E501
 
-    def test_given_storage_not_attached_when_pebble_ready_then_status_is_waiting(
+    def test_given_webui_data_not_available_when_pebble_ready_then_status_is_waiting(
         self, database_relation_id, nrf_relation_id, certificates_relation_id
+    ):
+        self.harness.add_storage(storage_name="certs", attach=True)
+        self.harness.add_storage(storage_name="config", attach=True)
+        self.mock_generate_private_key.return_value = PRIVATE_KEY
+        self.mock_is_resource_created.return_value = True
+        self.mock_nrf_url.return_value = NRF_URL
+        self.harness.add_relation(
+            relation_name=SDCORE_CONFIG_RELATION_NAME,
+            remote_app=WEBUI_APPLICATION_NAME,
+        )
+        self.mock_webui_url.return_value = ""
+        self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
+        self.harness.container_pebble_ready(CONTAINER_NAME)
+        self.harness.evaluate_status()
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for Webui data to be available")  # noqa: E501
+
+    def test_given_storage_not_attached_when_pebble_ready_then_status_is_waiting(
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.mock_generate_private_key.return_value = PRIVATE_KEY
@@ -220,7 +303,11 @@ class TestCharm:
         assert self.harness.model.unit.status == WaitingStatus("Waiting for storage to be attached")  # noqa: E501
 
     def test_given_certificates_not_stored_when_pebble_ready_then_status_is_waiting(
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
@@ -235,7 +322,11 @@ class TestCharm:
         assert self.harness.model.unit.status == WaitingStatus("Waiting for certificates to be stored")  # noqa: E501
 
     def test_given_relations_created_and_database_available_and_nrf_data_available_and_certs_stored_when_pebble_ready_then_config_file_rendered_and_pushed_correctly(  # noqa: E501
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
@@ -251,6 +342,7 @@ class TestCharm:
         ]
         self.mock_is_resource_created.return_value = True
         self.mock_nrf_url.return_value = NRF_URL
+        self.mock_webui_url.return_value = WEBUI_URL
         root = self.harness.get_filesystem_root(CONTAINER_NAME)
         (root / "support/TLS/amf.pem").write_text(certificate)
 
@@ -262,7 +354,11 @@ class TestCharm:
         assert (root / "free5gc/config/amfcfg.conf").read_text() == expected_content.strip()
 
     def test_given_content_of_config_file_not_changed_when_pebble_ready_then_config_file_is_not_pushed(  # noqa: E501
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
@@ -284,12 +380,17 @@ class TestCharm:
         self.mock_check_output.return_value = b"1.1.1.1"
         self.mock_is_resource_created.return_value = True
         self.mock_nrf_url.return_value = NRF_URL
+        self.mock_webui_url.return_value = WEBUI_URL
         self.harness.set_can_connect(container=CONTAINER_NAME, val=True)
         self.harness.container_pebble_ready(CONTAINER_NAME)
         assert (root / "free5gc/config/amfcfg.conf").stat().st_mtime == config_modification_time
 
     def test_given_relations_available_and_config_pushed_when_pebble_ready_then_pebble_is_applied_correctly(  # noqa: E501
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
@@ -333,7 +434,11 @@ class TestCharm:
         assert expected_plan == updated_plan
 
     def test_relations_available_and_config_pushed_and_pebble_updated_when_pebble_ready_then_status_is_active(  # noqa: E501
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
@@ -360,12 +465,15 @@ class TestCharm:
         assert self.harness.model.unit.status == ActiveStatus()
 
     def test_given_empty_ip_address_when_pebble_ready_then_status_is_waiting(
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="config", attach=True)
         self.mock_check_output.return_value = b""
         self.mock_nrf_url.return_value = NRF_URL
-
         self.harness.container_pebble_ready(container_name=CONTAINER_NAME)
         self.harness.evaluate_status()
         assert self.harness.charm.unit.status == WaitingStatus("Waiting for pod IP address to be available")  # noqa: E501
@@ -386,7 +494,11 @@ class TestCharm:
         assert relation_data == {}
 
     def test_given_n2_information_and_service_is_running_when_fiveg_n2_relation_joined_then_n2_information_is_in_relation_databag(  # noqa: E501
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
@@ -423,7 +535,11 @@ class TestCharm:
         assert relation_data["amf_port"] == "38412"
 
     def test_given_n2_information_and_service_is_running_and_n2_config_is_overriden_when_fiveg_n2_relation_joined_then_custom_n2_information_is_in_relation_databag(  # noqa: E501
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
@@ -463,7 +579,11 @@ class TestCharm:
         assert relation_data["amf_port"] == "38412"
 
     def test_given_n2_information_and_service_is_running_and_lb_service_has_no_hostname_when_fiveg_n2_relation_joined_then_internal_service_hostname_is_used(  # noqa: E501
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
@@ -499,7 +619,11 @@ class TestCharm:
         assert relation_data["amf_port"] == "38412"
 
     def test_given_n2_information_and_service_is_running_and_metallb_service_is_not_available_when_fiveg_n2_relation_joined_then_amf_goes_in_blocked_state(  # noqa: E501
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
@@ -529,7 +653,11 @@ class TestCharm:
         assert self.harness.charm.unit.status == BlockedStatus("Waiting for MetalLB to be enabled")
 
     def test_given_service_starts_running_after_n2_relation_joined_when_pebble_ready_then_n2_information_is_in_relation_databag(  # noqa: E501
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
@@ -571,7 +699,11 @@ class TestCharm:
         assert relation_data["amf_port"] == "38412"
 
     def test_given_more_than_one_n2_requirers_join_n2_relation_when_service_starts_then_n2_information_is_in_relation_databag(  # noqa: E501
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
@@ -619,7 +751,11 @@ class TestCharm:
         assert relation_data["amf_port"] == "38412"
 
     def test_given_can_connect_when_on_pebble_ready_then_private_key_is_generated(
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
@@ -665,7 +801,11 @@ class TestCharm:
             (root / "support/TLS/amf.csr").read_text()
 
     def test_given_certificates_are_stored_when_on_certificates_relation_broken_then_status_is_blocked(  # noqa: E501
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.harness.add_storage(storage_name="certs", attach=True)
         self.harness.add_storage(storage_name="config", attach=True)
@@ -682,7 +822,11 @@ class TestCharm:
         assert self.harness.charm.unit.status == BlockedStatus("Waiting for certificates relation")
 
     def test_given_private_key_exists_when_pebble_ready_then_csr_is_generated(
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.mock_check_output.return_value = b"1.1.1.1"
         self.harness.add_storage(storage_name="certs", attach=True)
@@ -699,7 +843,11 @@ class TestCharm:
         assert (root / "support/TLS/amf.csr").read_text() == CSR.decode()
 
     def test_given_private_key_exists_and_cert_not_yet_requested_when_pebble_ready_then_cert_is_requested(  # noqa: E501
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.mock_check_output.return_value = b"1.1.1.1"
         self.harness.add_storage(storage_name="certs", attach=True)
@@ -715,7 +863,11 @@ class TestCharm:
         self.mock_request_certificate_creation.assert_called_with(certificate_signing_request=CSR)
 
     def test_given_cert_already_stored_when_pebble_ready_then_cert_is_not_requested(  # noqa: E501
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.mock_check_output.return_value = b"1.1.1.1"
         self.harness.add_storage(storage_name="certs", attach=True)
@@ -738,7 +890,11 @@ class TestCharm:
         self.mock_request_certificate_creation.assert_not_called()
 
     def test_given_csr_matches_stored_one_when_pebble_ready_then_certificate_is_pushed(
-        self, database_relation_id, nrf_relation_id, certificates_relation_id
+        self,
+        database_relation_id,
+        nrf_relation_id,
+        certificates_relation_id,
+        sdcore_config_relation_id,
     ):
         self.mock_check_output.return_value = b"1.1.1.1"
         self.harness.add_storage(storage_name="certs", attach=True)


### PR DESCRIPTION
# Description

- Implement the requirer side of sdcore-config interface.
- Place main callback method `def _configure_amf` just after Charm constructor.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library