### PR TITLE
chore: move k8s specific code to its own class

### DIFF
--- a/src/k8s_service.py
+++ b/src/k8s_service.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# Copyright 2023 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""K8sService class to manage external AMF service."""
+
+import logging
+from typing import Optional
+
+from lightkube import Client
+from lightkube.models.core_v1 import ServicePort, ServiceSpec
+from lightkube.models.meta_v1 import ObjectMeta
+from lightkube.resources.core_v1 import Service
+
+logger = logging.getLogger(__name__)
+
+
+class K8sService:
+    """K8sService class to manage external AMF service."""
+
+    def __init__(self, namespace: str, service_name: str, service_port: int, app_name: str):
+        self.namespace = namespace
+        self.service_name = service_name
+        self.service_port = service_port
+        self.app_name = app_name
+
+    def create(self) -> None:
+        """Create the external AMF service."""
+        client = Client()
+        client.apply(
+            Service(
+                apiVersion="v1",
+                kind="Service",
+                metadata=ObjectMeta(
+                    namespace=self.namespace,
+                    name=self.service_name,
+                ),
+                spec=ServiceSpec(
+                    selector={"app.kubernetes.io/name": self.app_name},
+                    ports=[
+                        ServicePort(name="ngapp", port=self.service_port, protocol="SCTP"),
+                    ],
+                    type="LoadBalancer",
+                ),
+            ),
+            field_manager=self.app_name,
+        )
+        logger.info("Created/asserted existence of external AMF service")
+
+    def is_created(self) -> bool:
+        """Check if the external AMF service is created."""
+        client = Client()
+        try:
+            client.get(Service, name=self.service_name, namespace=self.namespace)
+            return True
+        except Exception:
+            return False
+
+    def remove(self):
+        """Remove the external AMF service."""
+        client = Client()
+        client.delete(
+            Service,
+            namespace=self.namespace,
+            name=self.service_name,
+        )
+        logger.info("Removed external AMF service")
+
+    def get_ip(self) -> Optional[str]:
+        """Return the external service IP."""
+        client = Client()
+        service = client.get(Service, name=self.service_name, namespace=self.namespace)
+        if not service.status:
+            return None
+        if not service.status.loadBalancer:
+            return None
+        if not service.status.loadBalancer.ingress:
+            return None
+        return service.status.loadBalancer.ingress[0].ip
+
+    def get_hostname(self) -> Optional[str]:
+        """Return the external service hostname."""
+        client = Client()
+        service = client.get(Service, name=self.service_name, namespace=self.namespace)
+        if not service.status:
+            return None
+        if not service.status.loadBalancer:
+            return None
+        if not service.status.loadBalancer.ingress:
+            return None
+        return service.status.loadBalancer.ingress[0].hostname


### PR DESCRIPTION
# Description

The AMF has k8s specific code used to create/remove the NGAP service. It used to be entangled in the charm class. Here , we move this k8s specific code to its own class and file. This separates concerns and move the dependencies closer to their actual use. This also allows for simplifying unit tests.

Here we did not write unit tests for this new class as it is a thin layer with close to 0 logic. 

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library