### PR TITLE
fix: catch API error when fetching external service

### DIFF
--- a/src/k8s_service.py
+++ b/src/k8s_service.py
@@ -8,10 +8,10 @@ import logging
 from typing import Optional
 
 from lightkube.core.client import Client
+from lightkube.core.exceptions import ApiError
 from lightkube.models.core_v1 import ServicePort, ServiceSpec
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Service
-from lightkube.core.exceptions import ApiError
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
# Description

There was an error introduced in one of my prior PR's that caused errors when getting the AMF external IP address (PR #345). Here we now catch  the lightkube APIError when fetching external service. 

## Logs

```
unit-sdcore-amf-k8s-0: 12:35:35 ERROR unit.sdcore-amf-k8s/0.juju-log Uncaught exception while in charm code:
Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/venv/lightkube/core/generic_client.py", line 188, in raise_for_status
    resp.raise_for_status()
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/venv/httpx/_models.py", line 761, in raise_for_status
    raise HTTPStatusError(message, request=request, response=self)
httpx.HTTPStatusError: Client error '404 Not Found' for url 'https://10.152.183.1/api/v1/namespaces/test-integration-9doe/services/sdcore-amf-k8s-external'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/404

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/./src/charm.py", line 825, in <module>
    main(AMFOperatorCharm)
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/venv/ops/main.py", line 551, in main
    manager.run()
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/venv/ops/main.py", line 530, in run
    self._emit()
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/venv/ops/main.py", line 521, in _emit
    ops.charm._evaluate_status(self.charm)
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/venv/ops/charm.py", line 1318, in _evaluate_status
    charm.on.collect_unit_status.emit()
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/venv/ops/framework.py", line 348, in emit
    framework._emit(event)
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/venv/ops/framework.py", line 860, in _emit
    self._reemit(event_path)
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/venv/ops/framework.py", line 950, in _reemit
    custom_handler(event)
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/./src/charm.py", line 249, in _on_collect_unit_status
    if not self._get_n2_amf_ip() or not self._get_n2_amf_hostname():
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/./src/charm.py", line 582, in _get_n2_amf_ip
    return self.k8s_service.get_ip()
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/src/k8s_service.py", line 72, in get_ip
    service = client.get(Service, name=self.service_name, namespace=self.namespace)
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/venv/lightkube/core/client.py", line 140, in get
    return self._client.request("get", res=res, name=name, namespace=namespace)
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/venv/lightkube/core/generic_client.py", line 245, in request
    return self.handle_response(method, resp, br)
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/venv/lightkube/core/generic_client.py", line 196, in handle_response
    self.raise_for_status(resp)
  File "/var/lib/juju/agents/unit-sdcore-amf-k8s-0/charm/venv/lightkube/core/generic_client.py", line 190, in raise_for_status
    raise transform_exception(e)
lightkube.core.exceptions.ApiError: services "sdcore-amf-k8s-external" not found```
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library