### PR TITLE
test: fix unit test that was not asserting that certificates were not updated unnecessarily

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -158,7 +158,6 @@ class AMFOperatorCharm(CharmBase):
         desired_config_file = self._generate_amf_config_file()
         if config_update_required := self._is_config_update_required(desired_config_file):
             self._push_config_file(content=desired_config_file)
-
         should_restart = config_update_required or certificate_update_required
         self._configure_pebble(restart=should_restart)
         try:

--- a/tests/unit/certificates_helpers.py
+++ b/tests/unit/certificates_helpers.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from lib.charms.tls_certificates_interface.v4.tls_certificates import (
+from charms.tls_certificates_interface.v4.tls_certificates import (
     PrivateKey,
     ProviderCertificate,
     generate_ca,


### PR DESCRIPTION
# Description

Here we had a unit test that was not going into the expected code path. We were never going to the point of comparing the existing cert to the new one.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library