### PR TITLE
chore: use built-in testing from ops

### DIFF
--- a/test-requirements.in
+++ b/test-requirements.in
@@ -6,4 +6,3 @@ pytest
 pytest-asyncio>=v0.21.2  # https://github.com/pytest-dev/pytest/issues/12269
 pytest-operator
 ruff
-ops-scenario

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -12,25 +12,29 @@ cachetools==5.5.0
     # via google-auth
 certifi==2024.8.30
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   requests
 cffi==1.17.1
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
-charset-normalizer==3.3.2
+charset-normalizer==3.4.0
     # via requests
 codespell==2.3.0
     # via -r test-requirements.in
-coverage[toml]==7.6.1
+coverage[toml]==7.6.2
     # via -r test-requirements.in
 cryptography==43.0.1
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
-durationpy==0.7
+durationpy==0.9
     # via kubernetes
 executing==2.1.0
     # via stack-data
@@ -39,17 +43,23 @@ google-auth==2.35.0
 hvac==2.3.0
     # via juju
 idna==3.10
-    # via requests
+    # via
+    #   -c requirements.txt
+    #   requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
-ipython==8.27.0
+ipython==8.28.0
     # via ipdb
 jedi==0.19.1
     # via ipython
 jinja2==3.1.4
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.5.2.0
     # via
     #   -r test-requirements.in
@@ -59,7 +69,9 @@ kubernetes==31.0.0
 macaroonbakery==1.3.4
     # via juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.7
     # via ipython
 mypy-extensions==1.0.0
@@ -70,12 +82,9 @@ oauthlib==3.2.2
     # via
     #   kubernetes
     #   requests-oauthlib
-ops==2.17.0
-    # via ops-scenario
-ops-scenario==7.0.5
-    # via -r test-requirements.in
 packaging==24.1
     # via
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.5.0
@@ -85,7 +94,9 @@ parso==0.8.4
 pexpect==4.9.0
     # via ipython
 pluggy==1.5.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.48
     # via ipython
 protobuf==5.28.2
@@ -102,7 +113,9 @@ pyasn1==0.6.1
 pyasn1-modules==0.4.1
     # via google-auth
 pycparser==2.22
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   cffi
 pygments==2.18.0
     # via ipython
 pymacaroons==0.13.0
@@ -116,10 +129,11 @@ pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
-pyright==1.1.383
+pyright==1.1.384
     # via -r test-requirements.in
 pytest==8.3.3
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-operator
@@ -135,10 +149,9 @@ pytz==2024.2
     # via pyrfc3339
 pyyaml==6.0.2
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
-    #   ops
-    #   ops-scenario
     #   pytest-operator
 requests==2.32.3
     # via
@@ -150,7 +163,7 @@ requests-oauthlib==2.0.0
     # via kubernetes
 rsa==4.9
     # via google-auth
-ruff==0.6.8
+ruff==0.6.9
     # via -r test-requirements.in
 six==1.16.0
     # via
@@ -169,6 +182,7 @@ traitlets==5.14.3
     #   matplotlib-inline
 typing-extensions==4.12.2
     # via
+    #   -c requirements.txt
     #   pyright
     #   typing-inspect
 typing-inspect==0.9.0
@@ -181,7 +195,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.8.0
     # via
+    #   -c requirements.txt
     #   kubernetes
-    #   ops
 websockets==13.1
     # via juju

--- a/tests/unit/fixtures.py
+++ b/tests/unit/fixtures.py
@@ -4,7 +4,7 @@
 from unittest.mock import PropertyMock, patch
 
 import pytest
-import scenario
+from ops import testing
 
 from charm import AMFOperatorCharm
 from k8s_service import K8sService
@@ -42,6 +42,6 @@ class AMFUnitTestFixtures:
 
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=AMFOperatorCharm,
         )

--- a/tests/unit/lib/charms/sdcore_amf/v0/test_fiveg_n2_provider_interface.py
+++ b/tests/unit/lib/charms/sdcore_amf/v0/test_fiveg_n2_provider_interface.py
@@ -3,9 +3,7 @@
 
 
 import pytest
-import scenario
-import scenario.errors
-from ops import ActionEvent, CharmBase
+from ops import ActionEvent, CharmBase, testing
 
 from lib.charms.sdcore_amf_k8s.v0.fiveg_n2 import N2Provides
 
@@ -37,7 +35,7 @@ class DummyFivegN2ProviderCharm(CharmBase):
 class TestFiveGN2Provider:
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=DummyFivegN2ProviderCharm,
             meta={
                 "name": "n2-provider-charm",
@@ -57,11 +55,11 @@ class TestFiveGN2Provider:
     def test_given_unit_is_leader_and_data_is_valid_when_set_fiveg_n2_information_then_data_is_in_application_databag(  # noqa: E501
         self,
     ):
-        fiveg_n2_relation = scenario.Relation(
+        fiveg_n2_relation = testing.Relation(
             endpoint="fiveg-n2",
             interface="fiveg_n2",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations={fiveg_n2_relation},
         )
@@ -82,11 +80,11 @@ class TestFiveGN2Provider:
     def test_given_unit_is_not_leader_when_fiveg_n2_relation_joined_then_data_is_not_in_application_databag(  # noqa: E501
         self,
     ):
-        fiveg_n2_relation = scenario.Relation(
+        fiveg_n2_relation = testing.Relation(
             endpoint="fiveg-n2",
             interface="fiveg_n2",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=False,
             relations={fiveg_n2_relation},
         )
@@ -98,7 +96,7 @@ class TestFiveGN2Provider:
         }
 
         # TODO: Shouldn't this use event.fail() rather than raising an exception?
-        with pytest.raises(scenario.errors.UncaughtCharmError) as e:
+        with pytest.raises(testing.errors.UncaughtCharmError) as e:
             self.ctx.run(self.ctx.on.action("set-n2-information", params=params), state_in)
 
         assert "Unit must be leader" in str(e.value)
@@ -106,11 +104,11 @@ class TestFiveGN2Provider:
     def test_given_unit_is_leader_but_port_is_invalid_when_fiveg_n2_relation_joined_then_value_error_is_raised(  # noqa: E501
         self,
     ):
-        fiveg_n2_relation = scenario.Relation(
+        fiveg_n2_relation = testing.Relation(
             endpoint="fiveg-n2",
             interface="fiveg_n2",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations={fiveg_n2_relation},
         )
@@ -122,7 +120,7 @@ class TestFiveGN2Provider:
         }
 
         # TODO: Shouldn't this use event.fail() rather than raising an exception?
-        with pytest.raises(scenario.errors.UncaughtCharmError) as e:
+        with pytest.raises(testing.errors.UncaughtCharmError) as e:
             self.ctx.run(self.ctx.on.action("set-n2-information", params=params), state_in)
 
         assert "Invalid relation data" in str(e.value)
@@ -130,11 +128,11 @@ class TestFiveGN2Provider:
     def test_given_unit_is_leader_but_ip_is_invalid_when_fiveg_n2_relation_joined_then_value_error_is_raised(  # noqa: E501
         self,
     ):
-        fiveg_n2_relation = scenario.Relation(
+        fiveg_n2_relation = testing.Relation(
             endpoint="fiveg-n2",
             interface="fiveg_n2",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations={fiveg_n2_relation},
         )
@@ -146,7 +144,7 @@ class TestFiveGN2Provider:
         }
 
         # TODO: Shouldn't this use event.fail() rather than raising an exception?
-        with pytest.raises(scenario.errors.UncaughtCharmError) as e:
+        with pytest.raises(testing.errors.UncaughtCharmError) as e:
             self.ctx.run(self.ctx.on.action("set-n2-information", params=params), state_in)
 
         assert "Invalid relation data" in str(e.value)

--- a/tests/unit/lib/charms/sdcore_amf/v0/test_fiveg_n2_requirer_interface.py
+++ b/tests/unit/lib/charms/sdcore_amf/v0/test_fiveg_n2_requirer_interface.py
@@ -3,8 +3,7 @@
 
 
 import pytest
-import scenario
-from ops import ActionEvent, CharmBase
+from ops import ActionEvent, CharmBase, testing
 
 from lib.charms.sdcore_amf_k8s.v0.fiveg_n2 import N2InformationAvailableEvent, N2Requires
 
@@ -32,7 +31,7 @@ class DummyFivegN2Requires(CharmBase):
 class TestFiveGNRFRequirer:
     @pytest.fixture(autouse=True)
     def context(self):
-        self.ctx = scenario.Context(
+        self.ctx = testing.Context(
             charm_type=DummyFivegN2Requires,
             meta={
                 "name": "n2-requirer-charm",
@@ -46,7 +45,7 @@ class TestFiveGNRFRequirer:
     def test_given_n2_information_in_relation_data_when_relation_changed_then_n2_information_available_event_emitted(  # noqa: E501
         self,
     ):
-        fiveg_n2_relation = scenario.Relation(
+        fiveg_n2_relation = testing.Relation(
             endpoint="fiveg-n2",
             interface="fiveg_n2",
             remote_app_data={
@@ -55,7 +54,7 @@ class TestFiveGNRFRequirer:
                 "amf_port": "38412",
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations={fiveg_n2_relation},
         )
@@ -71,11 +70,11 @@ class TestFiveGNRFRequirer:
     def test_given_n2_information_not_in_relation_data_when_relation_changed_then_n2_information_available_event_is_not_emitted(  # noqa: E501
         self,
     ):
-        fiveg_n2_relation = scenario.Relation(
+        fiveg_n2_relation = testing.Relation(
             endpoint="fiveg-n2",
             interface="fiveg_n2",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations={fiveg_n2_relation},
         )
@@ -87,7 +86,7 @@ class TestFiveGNRFRequirer:
     def test_given_invalid_n2_information_in_relation_data_when_relation_changed_then_n2_information_available_event_is_not_emitted(  # noqa: E501
         self,
     ):
-        fiveg_n2_relation = scenario.Relation(
+        fiveg_n2_relation = testing.Relation(
             endpoint="fiveg-n2",
             interface="fiveg_n2",
             remote_app_data={
@@ -96,7 +95,7 @@ class TestFiveGNRFRequirer:
                 "amf_port": "invalid_port123",
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations={fiveg_n2_relation},
         )
@@ -108,7 +107,7 @@ class TestFiveGNRFRequirer:
     def test_given_n2_information_in_relation_data_when_get_n2_information_is_called_then_information_is_returned(  # noqa: E501
         self,
     ):
-        fiveg_n2_relation = scenario.Relation(
+        fiveg_n2_relation = testing.Relation(
             endpoint="fiveg-n2",
             interface="fiveg_n2",
             remote_app_data={
@@ -117,7 +116,7 @@ class TestFiveGNRFRequirer:
                 "amf_port": "38412",
             },
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             relations={fiveg_n2_relation},
         )

--- a/tests/unit/test_charm_certificates_relation_broken.py
+++ b/tests/unit/test_charm_certificates_relation_broken.py
@@ -4,7 +4,7 @@
 import os
 import tempfile
 
-import scenario
+from ops import testing
 
 from tests.unit.certificates_helpers import (
     example_cert_and_key,
@@ -17,21 +17,21 @@ class TestCharmCertificatesRelationBroken(AMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
             provider_certificate, private_key = example_cert_and_key(
                 tls_relation_id=certificates_relation.id
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="amf",
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
@@ -44,7 +44,7 @@ class TestCharmCertificatesRelationBroken(AMFUnitTestFixtures):
             with open(f"{tempdir}/amf.key", "w") as f:
                 f.write(str(private_key))
 
-            state_in = scenario.State(
+            state_in = testing.State(
                 relations={certificates_relation},
                 containers={container},
                 leader=True,

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -3,8 +3,7 @@
 
 import tempfile
 
-import scenario
-from ops import ActiveStatus, BlockedStatus, WaitingStatus
+from ops import ActiveStatus, BlockedStatus, WaitingStatus, testing
 from ops.pebble import Layer, ServiceStatus
 
 from tests.unit.certificates_helpers import (
@@ -17,14 +16,14 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
     def test_given_fiveg_nrf_relation_not_created_when_collect_unit_status_then_status_is_blocked(
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates", interface="tls-certificates"
         )
-        sdcore_config_relation = scenario.Relation(
+        sdcore_config_relation = testing.Relation(
             endpoint="sdcore_config", interface="sdcore_config"
         )
-        container = scenario.Container(name="amf", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="amf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers={container},
             relations={certificates_relation, sdcore_config_relation},
@@ -37,12 +36,12 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
     def test_given_certificates_relation_not_created_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
         self,
     ):
-        nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-        sdcore_config_relation = scenario.Relation(
+        nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+        sdcore_config_relation = testing.Relation(
             endpoint="sdcore_config", interface="sdcore_config"
         )
-        container = scenario.Container(name="amf", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="amf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers={container},
             relations={nrf_relation, sdcore_config_relation},
@@ -55,12 +54,12 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
     def test_given_sdcore_config_relation_not_created_when_collect_unit_status_then_status_is_blocked(  # noqa: E501
         self,
     ):
-        nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-        certificates_relation = scenario.Relation(
+        nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+        certificates_relation = testing.Relation(
             endpoint="certificates", interface="tls-certificates"
         )
-        container = scenario.Container(name="amf", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="amf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers={container},
             relations={nrf_relation, certificates_relation},
@@ -73,15 +72,15 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
     def test_given_nrf_data_not_available_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        certificates_relation = scenario.Relation(
+        certificates_relation = testing.Relation(
             endpoint="certificates", interface="tls-certificates"
         )
-        sdcore_config_relation = scenario.Relation(
+        sdcore_config_relation = testing.Relation(
             endpoint="sdcore_config", interface="sdcore_config"
         )
-        nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-        container = scenario.Container(name="amf", can_connect=True)
-        state_in = scenario.State(
+        nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+        container = testing.Container(name="amf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers={container},
             relations={
@@ -99,15 +98,15 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
     def test_given_webui_data_not_available_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-        certificates_relation = scenario.Relation(
+        nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+        certificates_relation = testing.Relation(
             endpoint="certificates", interface="tls-certificates"
         )
-        sdcore_config_relation = scenario.Relation(
+        sdcore_config_relation = testing.Relation(
             endpoint="sdcore_config", interface="sdcore_config"
         )
-        container = scenario.Container(name="amf", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="amf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers={container},
             relations={
@@ -126,15 +125,15 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
     def test_given_storage_not_attached_when_collect_unit_status_then_status_is_waiting(
         self,
     ):
-        nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-        certificates_relation = scenario.Relation(
+        nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+        certificates_relation = testing.Relation(
             endpoint="certificates", interface="tls-certificates"
         )
-        sdcore_config_relation = scenario.Relation(
+        sdcore_config_relation = testing.Relation(
             endpoint="sdcore_config", interface="sdcore_config"
         )
-        container = scenario.Container(name="amf", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="amf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers={container},
             relations={
@@ -153,21 +152,21 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            sdcore_config_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            certificates_relation = scenario.Relation(
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="amf", can_connect=True, mounts={"config": config_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers={container},
                 relations={
@@ -190,22 +189,22 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="amf",
                 layers={
                     "amf": Layer(
@@ -233,7 +232,7 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
                 mounts={"certs": certs_mount, "config": config_mount},
                 service_statuses={"amf": ServiceStatus.ACTIVE},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers={container},
                 relations={
@@ -257,25 +256,25 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="amf", can_connect=True, mounts={"certs": certs_mount, "config": config_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers={container},
                 relations={
@@ -296,15 +295,15 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
     def test_given_no_workload_version_file_when_collect_unit_status_then_workload_version_not_set(
         self,
     ):
-        nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-        certificates_relation = scenario.Relation(
+        nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+        certificates_relation = testing.Relation(
             endpoint="certificates", interface="tls-certificates"
         )
-        sdcore_config_relation = scenario.Relation(
+        sdcore_config_relation = testing.Relation(
             endpoint="sdcore_config", interface="sdcore_config"
         )
-        container = scenario.Container(name="amf", can_connect=True)
-        state_in = scenario.State(
+        container = testing.Container(name="amf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers={container},
             relations={nrf_relation, certificates_relation, sdcore_config_relation},
@@ -318,14 +317,14 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            workload_version_mount = scenario.Mount(
+            workload_version_mount = testing.Mount(
                 location="/etc",
                 source=tempdir,
             )
@@ -333,10 +332,10 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
             expected_version = "1.2.3"
             with open(f"{tempdir}/workload-version", "w") as f:
                 f.write(expected_version)
-            container = scenario.Container(
+            container = testing.Container(
                 name="amf", can_connect=True, mounts={"workload-version": workload_version_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers={container},
                 relations={nrf_relation, certificates_relation, sdcore_config_relation},
@@ -350,23 +349,23 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            fiveg_n2_relation = scenario.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
-            config_mount = scenario.Mount(
+            fiveg_n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="amf",
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
@@ -394,7 +393,7 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
                 },
                 service_statuses={"amf": ServiceStatus.ACTIVE},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers={container},
                 relations={

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -4,7 +4,7 @@
 import os
 import tempfile
 
-import scenario
+from ops import testing
 from ops.pebble import Layer
 
 from tests.unit.certificates_helpers import (
@@ -18,25 +18,25 @@ class TestCharmConfigure(AMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="amf", can_connect=True, mounts={"certs": certs_mount, "config": config_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers={container},
                 relations={
@@ -73,25 +73,25 @@ class TestCharmConfigure(AMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="amf", can_connect=True, mounts={"certs": certs_mount, "config": config_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers={container},
                 relations={
@@ -130,25 +130,25 @@ class TestCharmConfigure(AMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="amf", can_connect=True, mounts={"certs": certs_mount, "config": config_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers={container},
                 relations={
@@ -191,28 +191,28 @@ class TestCharmConfigure(AMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            fiveg_n2_relation = scenario.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
-            config_mount = scenario.Mount(
+            fiveg_n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="amf",
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers={container},
                 relations={
@@ -244,29 +244,29 @@ class TestCharmConfigure(AMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            fiveg_n2_relation_1 = scenario.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
-            fiveg_n2_relation_2 = scenario.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
-            config_mount = scenario.Mount(
+            fiveg_n2_relation_1 = testing.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
+            fiveg_n2_relation_2 = testing.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="amf",
                 can_connect=True,
                 mounts={"certs": certs_mount, "config": config_mount},
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers={container},
                 relations={
@@ -304,25 +304,25 @@ class TestCharmConfigure(AMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            certs_mount = scenario.Mount(
+            certs_mount = testing.Mount(
                 location="/support/TLS",
                 source=tempdir,
             )
-            config_mount = scenario.Mount(
+            config_mount = testing.Mount(
                 location="/free5gc/config",
                 source=tempdir,
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="amf", can_connect=True, mounts={"certs": certs_mount, "config": config_mount}
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 containers={container},
                 relations={
@@ -346,28 +346,28 @@ class TestCharmConfigure(AMFUnitTestFixtures):
         self,
     ):
         with tempfile.TemporaryDirectory() as tempdir:
-            nrf_relation = scenario.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
-            certificates_relation = scenario.Relation(
+            nrf_relation = testing.Relation(endpoint="fiveg_nrf", interface="fiveg_nrf")
+            certificates_relation = testing.Relation(
                 endpoint="certificates", interface="tls-certificates"
             )
-            sdcore_config_relation = scenario.Relation(
+            sdcore_config_relation = testing.Relation(
                 endpoint="sdcore_config", interface="sdcore_config"
             )
-            container = scenario.Container(
+            container = testing.Container(
                 name="amf",
                 can_connect=True,
                 mounts={
-                    "certs": scenario.Mount(
+                    "certs": testing.Mount(
                         location="/support/TLS",
                         source=tempdir,
                     ),
-                    "config": scenario.Mount(
+                    "config": testing.Mount(
                         location="/free5gc/config",
                         source=tempdir,
                     ),
                 },
             )
-            state_in = scenario.State(
+            state_in = testing.State(
                 leader=True,
                 relations={
                     nrf_relation,
@@ -395,10 +395,10 @@ class TestCharmConfigure(AMFUnitTestFixtures):
             assert os.stat(tempdir + "/amf.key").st_mtime == config_modification_time_amf_key
 
     def test_given_k8s_service_not_created_when_pebble_ready_then_service_is_created(self):
-        container = scenario.Container(
+        container = testing.Container(
             name="amf",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             containers={container},
         )

--- a/tests/unit/test_charm_fiveg_n2_relation_joined.py
+++ b/tests/unit/test_charm_fiveg_n2_relation_joined.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 
-import scenario
+from ops import testing
 from ops.pebble import Layer, ServiceStatus
 
 from tests.unit.fixtures import AMFUnitTestFixtures
@@ -12,9 +12,9 @@ class TestCharmFiveGN2RelationJoined(AMFUnitTestFixtures):
     def test_given_service_not_running_when_fiveg_n2_relation_joined_then_n2_information_is_not_in_relation_databag(  # noqa: E501
         self,
     ):
-        fiveg_n2_relation = scenario.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
-        container = scenario.Container(name="amf", can_connect=True)
-        state_in = scenario.State(
+        fiveg_n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
+        container = testing.Container(name="amf", can_connect=True)
+        state_in = testing.State(
             leader=True,
             containers={container},
             relations={fiveg_n2_relation},
@@ -30,8 +30,8 @@ class TestCharmFiveGN2RelationJoined(AMFUnitTestFixtures):
     def test_given_n2_information_and_service_is_running_when_fiveg_n2_relation_joined_then_n2_information_is_in_relation_databag(  # noqa: E501
         self,
     ):
-        fiveg_n2_relation = scenario.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
-        container = scenario.Container(
+        fiveg_n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
+        container = testing.Container(
             name="amf",
             can_connect=True,
             layers={
@@ -58,7 +58,7 @@ class TestCharmFiveGN2RelationJoined(AMFUnitTestFixtures):
             },
             service_statuses={"amf": ServiceStatus.ACTIVE},
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             containers={container},
             relations={
@@ -79,8 +79,8 @@ class TestCharmFiveGN2RelationJoined(AMFUnitTestFixtures):
     def test_given_n2_information_and_service_is_running_and_n2_config_is_overriden_when_fiveg_n2_relation_joined_then_custom_n2_information_is_in_relation_databag(  # noqa: E501
         self,
     ):
-        fiveg_n2_relation = scenario.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
-        container = scenario.Container(
+        fiveg_n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
+        container = testing.Container(
             name="amf",
             can_connect=True,
             layers={
@@ -107,7 +107,7 @@ class TestCharmFiveGN2RelationJoined(AMFUnitTestFixtures):
             },
             service_statuses={"amf": ServiceStatus.ACTIVE},
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             config={
                 "external-amf-ip": "192.0.2.2",
                 "external-amf-hostname": "amf.burger.example.com",
@@ -133,8 +133,8 @@ class TestCharmFiveGN2RelationJoined(AMFUnitTestFixtures):
         self,
     ):
         model_name = "whatever"
-        fiveg_n2_relation = scenario.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
-        container = scenario.Container(
+        fiveg_n2_relation = testing.Relation(endpoint="fiveg-n2", interface="fiveg-n2")
+        container = testing.Container(
             name="amf",
             can_connect=True,
             layers={
@@ -161,8 +161,8 @@ class TestCharmFiveGN2RelationJoined(AMFUnitTestFixtures):
             },
             service_statuses={"amf": ServiceStatus.ACTIVE},
         )
-        state_in = scenario.State(
-            model=scenario.Model(
+        state_in = testing.State(
+            model=testing.Model(
                 name=model_name,
             ),
             config={"external-amf-ip": "192.0.2.2"},

--- a/tests/unit/test_charm_remove.py
+++ b/tests/unit/test_charm_remove.py
@@ -2,17 +2,17 @@
 # See LICENSE file for licensing details.
 
 
-import scenario
+from ops import testing
 
 from tests.unit.fixtures import AMFUnitTestFixtures
 
 
 class TestCharmRemove(AMFUnitTestFixtures):
     def test_given_k8s_service_created_when_remove_then_external_service_is_deleted(self):
-        container = scenario.Container(
+        container = testing.Container(
             name="amf",
         )
-        state_in = scenario.State(
+        state_in = testing.State(
             leader=True,
             containers={container},
         )


### PR DESCRIPTION
# Description

Now that scenario testing is built into ops we don't need to import it as a separate dependency. Here we use `ops.testing` instead of scenario. Both have the same API.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library