### PR TITLE
feat: add NMS integration with TLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ juju deploy self-signed-certificates --channel=stable
 juju deploy sdcore-nms-k8s --channel=1.5/edge
 juju integrate sdcore-nms-k8s:common_database mongodb-k8s:database
 juju integrate sdcore-nms-k8s:auth_database mongodb-k8s:database
+juju integrate sdcore-nms-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-nrf-k8s:database mongodb-k8s:database
 juju integrate sdcore-nrf-k8s:certificates self-signed-certificates:certificates
 juju integrate sdcore-nrf-k8s:sdcore_config sdcore-webui-k8s:sdcore-config

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -177,3 +177,4 @@ async def _deploy_nms(ops_test: OpsTest):
     await ops_test.model.integrate(
         relation1=f"{NMS_CHARM_NAME}:auth_database", relation2=f"{DB_CHARM_NAME}"
     )
+    await ops_test.model.integrate(relation1=NMS_CHARM_NAME, relation2=TLS_PROVIDER_CHARM_NAME)


### PR DESCRIPTION
# Description

This PR adds the NMS integration with the TLS to the integration tests.
TLS certificates integration is mandatory for NMS and the NMS charm does not share the webui address until this relation exists.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library