### PR TITLE
chore: Configures renovate to cover v1.5 release branch

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,17 +20,22 @@
   "packageRules": [
     // Later rules override earlier rules
     {
+      "matchBaseBranches": ["main", "v*"],
       "matchManagers": ["pep621"],
       "rangeStrategy": "bump",
       "groupName": "Python dependencies"
     },
     {
+      "matchBaseBranches": ["main", "v*"],
       "matchManagers": ["github-actions"],
       "groupName": "GitHub actions"
     },
     {
+      "matchBaseBranches": ["main", "v*"],
       "matchManagers": ["terraform"],
       "groupName": "Terraform"
     },
   ],
+  // Bumping "pytest-asyncio" over 0.23 breaks the integration tests
+  "ignoreDeps": ["pytest-asyncio"]
 }


### PR DESCRIPTION
# Description

- Configures renovate to cover `v1.5` release branch
- Excludes `pytest-asyncio` from renovate updates

Reference:
https://docs.renovatebot.com/configuration-options/#matchbasebranches

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library