### PR TITLE
feat: add log-level configuration option

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -79,6 +79,10 @@ parts:
 
 config:
   options:
+    log-level:
+      type: string
+      default: info
+      description: Log level for the AMF. One of `debug`, `info`, `warn`, `error`, `fatal`, `panic`.
     dnn:
       type: string
       default: internet

--- a/src/templates/amfcfg.conf.j2
+++ b/src/templates/amfcfg.conf.j2
@@ -64,6 +64,9 @@ configuration:
     enable: true
     expireTime: 6s
     maxRetryTimes: 4
+logger:
+  AMF:
+    debugLevel: {{ log_level }}
 info:
   description: AMF initial configuration
   version: 1.0.0

--- a/tests/unit/expected_config/config.conf
+++ b/tests/unit/expected_config/config.conf
@@ -64,6 +64,9 @@ configuration:
     enable: true
     expireTime: 6s
     maxRetryTimes: 4
+logger:
+  AMF:
+    debugLevel: info
 info:
   description: AMF initial configuration
   version: 1.0.0

--- a/tests/unit/test_charm_collect_status.py
+++ b/tests/unit/test_charm_collect_status.py
@@ -13,6 +13,22 @@ from tests.unit.fixtures import AMFUnitTestFixtures
 
 
 class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
+    def test_given_invalid_log_level_config_when_collect_unit_status_then_status_is_blocked(
+        self,
+    ):
+        container = testing.Container(name="amf", can_connect=True)
+        state_in = testing.State(
+            leader=True,
+            config={"log-level": "invalid"},
+            containers={container},
+        )
+
+        state_out = self.ctx.run(self.ctx.on.collect_unit_status(), state_in)
+
+        assert state_out.unit_status == BlockedStatus(
+            "The following configurations are not valid: ['log-level']"
+        )
+
     def test_given_fiveg_nrf_relation_not_created_when_collect_unit_status_then_status_is_blocked(
         self,
     ):
@@ -216,10 +232,6 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
                                     "command": "/bin/amf --amfcfg /free5gc/config/amfcfg.conf",
                                     "environment": {
                                         "GOTRACEBACK": "crash",
-                                        "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
-                                        "GRPC_GO_LOG_SEVERITY_LEVEL": "info",
-                                        "GRPC_TRACE": "all",
-                                        "GRPC_VERBOSITY": "DEBUG",
                                         "POD_IP": "192.0.2.1",
                                         "MANAGED_BY_CONFIG_POD": "true",
                                     },
@@ -379,10 +391,6 @@ class TestCharmCollectUnitStatus(AMFUnitTestFixtures):
                                     "command": "/bin/amf --amfcfg /free5gc/config/amfcfg.conf",
                                     "environment": {
                                         "GOTRACEBACK": "crash",
-                                        "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
-                                        "GRPC_GO_LOG_SEVERITY_LEVEL": "info",
-                                        "GRPC_TRACE": "all",
-                                        "GRPC_VERBOSITY": "DEBUG",
                                         "POD_IP": "192.0.2.1",
                                         "MANAGED_BY_CONFIG_POD": "true",
                                     },

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -175,10 +175,6 @@ class TestCharmConfigure(AMFUnitTestFixtures):
                             "command": "/bin/amf --amfcfg /free5gc/config/amfcfg.conf",
                             "environment": {
                                 "GOTRACEBACK": "crash",
-                                "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
-                                "GRPC_GO_LOG_SEVERITY_LEVEL": "info",
-                                "GRPC_TRACE": "all",
-                                "GRPC_VERBOSITY": "DEBUG",
                                 "POD_IP": "192.0.2.1",
                                 "MANAGED_BY_CONFIG_POD": "true",
                             },

--- a/tests/unit/test_charm_fiveg_n2_relation_joined.py
+++ b/tests/unit/test_charm_fiveg_n2_relation_joined.py
@@ -44,10 +44,6 @@ class TestCharmFiveGN2RelationJoined(AMFUnitTestFixtures):
                                 "command": "/bin/amf --amfcfg /free5gc/config/amfcfg.conf",
                                 "environment": {
                                     "GOTRACEBACK": "crash",
-                                    "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
-                                    "GRPC_GO_LOG_SEVERITY_LEVEL": "info",
-                                    "GRPC_TRACE": "all",
-                                    "GRPC_VERBOSITY": "DEBUG",
                                     "POD_IP": "192.0.2.1",
                                     "MANAGED_BY_CONFIG_POD": "true",
                                 },
@@ -93,10 +89,6 @@ class TestCharmFiveGN2RelationJoined(AMFUnitTestFixtures):
                                 "command": "/bin/amf --amfcfg /free5gc/config/amfcfg.conf",
                                 "environment": {
                                     "GOTRACEBACK": "crash",
-                                    "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
-                                    "GRPC_GO_LOG_SEVERITY_LEVEL": "info",
-                                    "GRPC_TRACE": "all",
-                                    "GRPC_VERBOSITY": "DEBUG",
                                     "POD_IP": "192.0.2.1",
                                     "MANAGED_BY_CONFIG_POD": "true",
                                 },
@@ -147,10 +139,6 @@ class TestCharmFiveGN2RelationJoined(AMFUnitTestFixtures):
                                 "command": "/bin/amf --amfcfg /free5gc/config/amfcfg.conf",
                                 "environment": {
                                     "GOTRACEBACK": "crash",
-                                    "GRPC_GO_LOG_VERBOSITY_LEVEL": "99",
-                                    "GRPC_GO_LOG_SEVERITY_LEVEL": "info",
-                                    "GRPC_TRACE": "all",
-                                    "GRPC_VERBOSITY": "DEBUG",
                                     "POD_IP": "192.0.2.1",
                                     "MANAGED_BY_CONFIG_POD": "true",
                                 },


### PR DESCRIPTION
# Description

Here we add a `log-level` configuration option with a reasonable default value (`info`). The allowed options are the same as in the AMF workload: `debug`, `info`, `warn`, `error`, `fatal`, `panic`.

## Rationale

In most deployments, the log level should be set to `info` to ensure the log quantity is reasonable. 

## Logs

```
2024-12-05T14:21:38.034Z [pebble] Service "amf" starting: /bin/amf --amfcfg /free5gc/config/amfcfg.conf
2024-12-05T14:21:38.044Z [amf] 2024-12-05T14:21:38.044Z	INFO	build/amf.go:24	amf	{"component": "AMF", "category": "App"}
2024-12-05T14:21:38.045Z [amf] 2024-12-05T14:21:38.045Z	INFO	service/init.go:239	AMF Log level is set to [info] level	{"component": "AMF", "category": "Init"}
2024-12-05T14:21:38.045Z [amf] 2024-12-05T14:21:38.045Z	INFO	logger/logger.go:103	set log level: info	{"component": "AMF", "category": "CFG"}
2024-12-05T14:21:38.045Z [amf] 2024-12-05T14:21:38.045Z	INFO	factory/factory.go:136	config version [1.0.0]	{"component": "AMF", "category": "CFG"}
2024-12-05T14:21:38.045Z [amf] 2024-12-05T14:21:38.045Z	INFO	service/init.go:147	Reading Amf related configuration from ROC	{"component": "AMF", "category": "Init"}
2024-12-05T14:21:38.045Z [amf] 2024-12-05T14:21:38.045Z	INFO	service/init.go:323	server started	{"component": "AMF", "category": "Init"}
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library