### PR TITLE
feat: specify the configuration path to use AMF version 1.6.0

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -20,7 +20,7 @@ resources:
   amf-image:
     type: oci-image
     description: OCI image for SD-Core amf
-    upstream-source: ghcr.io/canonical/sdcore-amf:1.5.1
+    upstream-source: ghcr.io/canonical/sdcore-amf:1.6.1
 
 storage:
   config:

--- a/src/charm.py
+++ b/src/charm.py
@@ -58,7 +58,7 @@ CONFIG_FILE_NAME = "amfcfg.conf"
 CONFIG_TEMPLATE_DIR_PATH = "src/templates/"
 CONFIG_TEMPLATE_NAME = "amfcfg.conf.j2"
 WORKLOAD_VERSION_FILE_NAME = "/etc/workload-version"
-CERTS_DIR_PATH = "/support/TLS"  # Certificate paths are hardcoded in AMF code
+CERTS_DIR_PATH = "/support/TLS"
 PRIVATE_KEY_NAME = "amf.key"
 CERTIFICATE_NAME = "amf.pem"
 CERTIFICATE_COMMON_NAME = "amf.sdcore"
@@ -582,6 +582,8 @@ class AMFOperatorCharm(CharmBase):
             scheme="https",
             webui_uri=self._webui_requires.webui_url,
             log_level=log_level,
+            tls_pem=f"{CERTS_DIR_PATH}/{CERTIFICATE_NAME}",
+            tls_key=f"{CERTS_DIR_PATH}/{PRIVATE_KEY_NAME}",
         )
 
     @staticmethod
@@ -598,6 +600,8 @@ class AMFOperatorCharm(CharmBase):
         scheme: str,
         webui_uri: str,
         log_level: str,
+        tls_pem: str,
+        tls_key: str,
     ) -> str:
         """Render the AMF config file.
 
@@ -613,6 +617,8 @@ class AMFOperatorCharm(CharmBase):
             scheme (str): SBI interface scheme ("http" or "https")
             webui_uri (str) : URL of the Webui.
             log_level (str): Log level for the AMF.
+            tls_pem (str): TLS certificate file.
+            tls_key (str): TLS key file.
 
         Returns:
             str: Content of the rendered config file.
@@ -631,6 +637,8 @@ class AMFOperatorCharm(CharmBase):
             scheme=scheme,
             webui_uri=webui_uri,
             log_level=log_level,
+            tls_pem=tls_pem,
+            tls_key=tls_key,
         )
         return content
 
@@ -683,7 +691,7 @@ class AMFOperatorCharm(CharmBase):
                     self._amf_service_name: {
                         "override": "replace",
                         "startup": "enabled",
-                        "command": f"/bin/amf --amfcfg {CONFIG_DIR_PATH}/{CONFIG_FILE_NAME}",  # noqa: E501
+                        "command": f"/bin/amf --cfg {CONFIG_DIR_PATH}/{CONFIG_FILE_NAME}",
                         "environment": self._amf_environment_variables,
                     },
                 },

--- a/src/templates/amfcfg.conf.j2
+++ b/src/templates/amfcfg.conf.j2
@@ -24,6 +24,9 @@ configuration:
     port: {{ sbi_port }}
     registerIPv4: {{ amf_ip }}
     scheme: {{ scheme }}
+    tls:
+      pem: {{ tls_pem }}
+      key: {{ tls_key }}
   sctpGrpcPort: {{ sctp_grpc_port }}
   serviceNameList:
     - namf-comm

--- a/tests/unit/expected_config/config.conf
+++ b/tests/unit/expected_config/config.conf
@@ -24,6 +24,9 @@ configuration:
     port: 29518
     registerIPv4: 192.0.2.1
     scheme: https
+    tls:
+      pem: /support/TLS/amf.pem
+      key: /support/TLS/amf.key
   sctpGrpcPort: 9000
   serviceNameList:
     - namf-comm

--- a/tests/unit/test_charm_configure.py
+++ b/tests/unit/test_charm_configure.py
@@ -115,15 +115,22 @@ class TestCharmConfigure(AMFUnitTestFixtures):
                 f.write(str(private_key))
 
             with open("tests/unit/expected_config/config.conf", "r") as f:
-                expected_config = f.read().strip()
+                expected_config = f.read()
 
             with open(tempdir + "/amfcfg.conf", "w") as f:
-                f.write(expected_config)
+                f.write(expected_config.strip())
 
             config_modification_time = os.stat(tempdir + "/amfcfg.conf").st_mtime
 
             self.ctx.run(self.ctx.on.pebble_ready(container), state_in)
 
+            with open(tempdir + "/amfcfg.conf", "r") as config_file:
+                actual_config = config_file.read()
+
+            with open("tests/unit/expected_config/config.conf", "r") as expected_config_file:
+                expected_config = expected_config_file.read()
+
+            assert actual_config.strip() == expected_config.strip()
             assert os.stat(tempdir + "/amfcfg.conf").st_mtime == config_modification_time
 
     def test_given_relations_available_and_config_pushed_when_pebble_ready_then_pebble_is_applied_correctly(  # noqa: E501
@@ -172,7 +179,7 @@ class TestCharmConfigure(AMFUnitTestFixtures):
                         "amf": {
                             "startup": "enabled",
                             "override": "replace",
-                            "command": "/bin/amf --amfcfg /free5gc/config/amfcfg.conf",
+                            "command": "/bin/amf --cfg /free5gc/config/amfcfg.conf",
                             "environment": {
                                 "GOTRACEBACK": "crash",
                                 "POD_IP": "192.0.2.1",


### PR DESCRIPTION
# Description

TLS paths and  the configuration paths are parameterized in the Upstream with AMF version 1.6.0.
To use the Workload 1.6.0 and higher versions, this PR which specifies configuration and TLS file paths is required.

`Warning: A new Rock version (1.6.0 or higher) should be used with this PR. Integration tests fails until we create a new Rock version and start to use it.`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library