### PR TITLE
fix: Uses ubuntu@24.04 in TF module and integration tests

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,7 @@ resource "juju_application" "amf" {
     name     = "sdcore-amf-k8s"
     channel  = var.channel
     revision = var.revision
+    base     = var.base
   }
 
   config      = var.config

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -43,6 +43,12 @@ variable "revision" {
   default     = null
 }
 
+variable "base" {
+  description = "The operating system on which to deploy"
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "units" {
   description = "Number of units to deploy"
   type        = number

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -24,6 +24,7 @@ NMS_CHARM_NAME = "sdcore-nms-k8s"
 NMS_CHARM_CHANNEL = "1.5/edge"
 GRAFANA_AGENT_CHARM_NAME = "grafana-agent-k8s"
 GRAFANA_AGENT_CHARM_CHANNEL = "latest/stable"
+SDCORE_CHARMS_BASE = "ubuntu@24.04"
 TIMEOUT = 15 * 60
 
 
@@ -156,6 +157,7 @@ async def _deploy_nrf(ops_test: OpsTest):
         NRF_CHARM_NAME,
         application_name=NRF_CHARM_NAME,
         channel=NRF_CHARM_CHANNEL,
+        base=SDCORE_CHARMS_BASE,
     )
     await ops_test.model.integrate(
         relation1=f"{NRF_CHARM_NAME}:database", relation2=f"{DB_CHARM_NAME}"
@@ -170,6 +172,7 @@ async def _deploy_nms(ops_test: OpsTest):
         NMS_CHARM_NAME,
         application_name=NMS_CHARM_NAME,
         channel=NMS_CHARM_CHANNEL,
+        base=SDCORE_CHARMS_BASE,
     )
     await ops_test.model.integrate(
         relation1=f"{NMS_CHARM_NAME}:common_database", relation2=f"{DB_CHARM_NAME}"

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -24,7 +24,7 @@ NMS_CHARM_NAME = "sdcore-nms-k8s"
 NMS_CHARM_CHANNEL = "1.5/edge"
 GRAFANA_AGENT_CHARM_NAME = "grafana-agent-k8s"
 GRAFANA_AGENT_CHARM_CHANNEL = "latest/stable"
-SDCORE_CHARMS_BASE = "ubuntu@24.04"
+SDCORE_CHARMS_SERIES = "noble"
 TIMEOUT = 15 * 60
 
 
@@ -157,7 +157,7 @@ async def _deploy_nrf(ops_test: OpsTest):
         NRF_CHARM_NAME,
         application_name=NRF_CHARM_NAME,
         channel=NRF_CHARM_CHANNEL,
-        base=SDCORE_CHARMS_BASE,
+        series=SDCORE_CHARMS_SERIES, # TODO: This should be replaced with base="ubuntu@24.04" once it's properly supported # noqa: E501
     )
     await ops_test.model.integrate(
         relation1=f"{NRF_CHARM_NAME}:database", relation2=f"{DB_CHARM_NAME}"
@@ -172,7 +172,7 @@ async def _deploy_nms(ops_test: OpsTest):
         NMS_CHARM_NAME,
         application_name=NMS_CHARM_NAME,
         channel=NMS_CHARM_CHANNEL,
-        base=SDCORE_CHARMS_BASE,
+        series=SDCORE_CHARMS_SERIES, # TODO: This should be replaced with base="ubuntu@24.04" once it's properly supported # noqa: E501
     )
     await ops_test.model.integrate(
         relation1=f"{NMS_CHARM_NAME}:common_database", relation2=f"{DB_CHARM_NAME}"


### PR DESCRIPTION
# Description

By default, Juju fetches charms with base matching the host OS. It means that when running Jammy, Juju won’t use latest charms, because we’ve changed the base to Noble.

Adding an optional (as per CC006) config param base will allow using Noble (base should be set to ubuntu@24.04) regardless of the host OS.

Enforcing Noble on a Juju model configuration level is not an option, because it breaks COS integration (COS charms are not available in ubuntu@24.04).

## ATTENTION
As a workaround to this issue https://github.com/juju/python-libjuju/issues/1240 we use, series instead of base in the integration tests.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library