### PR TITLE
chore: bump amf rock to v1.6.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ juju config sdcore-amf-k8s external-amf-ip=192.168.0.4 external-amf-hostname=amf
 
 ## Image
 
-**amf**: ghcr.io/canonical/sdcore-amf:1.5.1
+**amf**: ghcr.io/canonical/sdcore-amf:1.6.4

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -20,7 +20,7 @@ resources:
   amf-image:
     type: oci-image
     description: OCI image for SD-Core amf
-    upstream-source: ghcr.io/canonical/sdcore-amf:1.6.1
+    upstream-source: ghcr.io/canonical/sdcore-amf:1.6.4
 
 storage:
   config:


### PR DESCRIPTION
# Description

Bump the underlying workload to the latest upstream release: v1.6.4

## Reference
- https://github.com/omec-project/amf/releases/tag/v1.6.4

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library