### PR TITLE
chore: TICS static analysis require coverage.xml

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -50,6 +50,7 @@ description = Run unit tests
 commands =
     coverage run --source={[vars]src_path} -m pytest {[vars]unit_test_path} -v --tb native -s {posargs}
     coverage report
+    coverage xml
 
 [testenv:integration]
 description = Run integration tests


### PR DESCRIPTION
# Description

Update tox file to produce a `coverage.xml` when unit tests run.This is necessary as TICS static analysis requires a coverage.xml.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library