### PR TITLE
fix: Ignores minor version updates for Python

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -34,12 +34,14 @@
       matchManagers: [
         'pep621',
       ],
+
       rangeStrategy: 'bump',
       groupName: 'Python dependencies',
     },
     {
       matchPackageNames: [
         'pytest-asyncio',
+        'python'
       ],
       matchUpdateTypes: [
         'minor',


### PR DESCRIPTION
# Description

This PR aims at fixing Renovate PRs by ignoring the minor version updates for Python.
The idea is to use Python version shipped with current Ubuntu LTS.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library