### PR TITLE
feat: add amf tracing support

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -52,6 +52,9 @@ requires:
   tracing:
     interface: tracing
     limit: 1
+  charm_tracing:
+    interface: tracing
+    limit: 1
 
 type: charm
 base: ubuntu@24.04

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -52,9 +52,11 @@ requires:
   tracing:
     interface: tracing
     limit: 1
+    optional: true
   charm_tracing:
     interface: tracing
     limit: 1
+    optional: true
 
 type: charm
 base: ubuntu@24.04

--- a/lib/charms/tempo_coordinator_k8s/v0/tracing.py
+++ b/lib/charms/tempo_coordinator_k8s/v0/tracing.py
@@ -1,0 +1,994 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+"""## Overview.
+
+This document explains how to integrate with the Tempo charm for the purpose of pushing traces to a
+tracing endpoint provided by Tempo. It also explains how alternative implementations of the Tempo charm
+may maintain the same interface and be backward compatible with all currently integrated charms.
+
+## Requirer Library Usage
+
+Charms seeking to push traces to Tempo, must do so using the `TracingEndpointRequirer`
+object from this charm library. For the simplest use cases, using the `TracingEndpointRequirer`
+object only requires instantiating it, typically in the constructor of your charm. The
+`TracingEndpointRequirer` constructor requires the name of the relation over which a tracing endpoint
+ is exposed by the Tempo charm, and a list of protocols it intends to send traces with.
+ This relation must use the `tracing` interface.
+ The `TracingEndpointRequirer` object may be instantiated as follows
+
+    from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointRequirer
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        # ...
+        self.tracing = TracingEndpointRequirer(self,
+            protocols=['otlp_grpc', 'otlp_http', 'jaeger_http_thrift']
+        )
+        # ...
+
+Note that the first argument (`self`) to `TracingEndpointRequirer` is always a reference to the
+parent charm.
+
+Alternatively to providing the list of requested protocols at init time, the charm can do it at
+any point in time by calling the
+`TracingEndpointRequirer.request_protocols(*protocol:str, relation:Optional[Relation])` method.
+Using this method also allows you to use per-relation protocols.
+
+Units of requirer charms obtain the tempo endpoint to which they will push their traces by calling
+`TracingEndpointRequirer.get_endpoint(protocol: str)`, where `protocol` is, for example:
+- `otlp_grpc`
+- `otlp_http`
+- `zipkin`
+- `tempo`
+
+If the `protocol` is not in the list of protocols that the charm requested at endpoint set-up time,
+the library will raise an error.
+
+We recommend that you scale up your tracing provider and relate it to an ingress so that your tracing requests
+go through the ingress and get load balanced across all units. Otherwise, if the provider's leader goes down, your tracing goes down.
+
+## Provider Library Usage
+
+The `TracingEndpointProvider` object may be used by charms to manage relations with their
+trace sources. For this purposes a Tempo-like charm needs to do two things
+
+1. Instantiate the `TracingEndpointProvider` object by providing it a
+reference to the parent (Tempo) charm and optionally the name of the relation that the Tempo charm
+uses to interact with its trace sources. This relation must conform to the `tracing` interface
+and it is strongly recommended that this relation be named `tracing` which is its
+default value.
+
+For example a Tempo charm may instantiate the `TracingEndpointProvider` in its constructor as
+follows
+
+    from charms.tempo_coordinator_k8s.v0.tracing import TracingEndpointProvider
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        # ...
+        self.tracing = TracingEndpointProvider(self)
+        # ...
+
+
+
+"""  # noqa: W505
+import enum
+import json
+import logging
+from pathlib import Path
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Dict,
+    List,
+    Literal,
+    MutableMapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Union,
+    cast,
+)
+
+import pydantic
+from ops.charm import (
+    CharmBase,
+    CharmEvents,
+    RelationBrokenEvent,
+    RelationEvent,
+    RelationRole,
+)
+from ops.framework import EventSource, Object
+from ops.model import ModelError, Relation
+from pydantic import BaseModel, Field
+
+# The unique Charmhub library identifier, never change it
+LIBID = "d2f02b1f8d1244b5989fd55bc3a28943"
+
+# Increment this major API version when introducing breaking changes
+LIBAPI = 0
+
+# Increment this PATCH version before using `charmcraft publish-lib` or reset
+# to 0 if you are raising the major API version
+LIBPATCH =  8
+
+PYDEPS = ["pydantic"]
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_RELATION_NAME = "tracing"
+RELATION_INTERFACE_NAME = "tracing"
+
+# Supported list rationale https://github.com/canonical/tempo-coordinator-k8s-operator/issues/8
+ReceiverProtocol = Literal[
+    "zipkin",
+    "otlp_grpc",
+    "otlp_http",
+    "jaeger_grpc",
+    "jaeger_thrift_http",
+]
+
+RawReceiver = Tuple[ReceiverProtocol, str]
+# Helper type. A raw receiver is defined as a tuple consisting of the protocol name, and the (external, if available),
+# (secured, if available) resolvable server url.
+
+
+BUILTIN_JUJU_KEYS = {"ingress-address", "private-address", "egress-subnets"}
+
+
+class TransportProtocolType(str, enum.Enum):
+    """Receiver Type."""
+
+    http = "http"
+    grpc = "grpc"
+
+
+receiver_protocol_to_transport_protocol: Dict[ReceiverProtocol, TransportProtocolType] = {
+    "zipkin": TransportProtocolType.http,
+    "otlp_grpc": TransportProtocolType.grpc,
+    "otlp_http": TransportProtocolType.http,
+    "jaeger_thrift_http": TransportProtocolType.http,
+    "jaeger_grpc": TransportProtocolType.grpc,
+}
+# A mapping between telemetry protocols and their corresponding transport protocol.
+
+
+class TracingError(Exception):
+    """Base class for custom errors raised by this library."""
+
+
+class NotReadyError(TracingError):
+    """Raised by the provider wrapper if a requirer hasn't published the required data (yet)."""
+
+
+class ProtocolNotRequestedError(TracingError):
+    """Raised if the user attempts to obtain an endpoint for a protocol it did not request."""
+
+
+class DataValidationError(TracingError):
+    """Raised when data validation fails on IPU relation data."""
+
+
+class DataAccessPermissionError(TracingError):
+    """Raised when follower units attempt leader-only operations."""
+
+
+class AmbiguousRelationUsageError(TracingError):
+    """Raised when one wrongly assumes that there can only be one relation on an endpoint."""
+
+
+if int(pydantic.version.VERSION.split(".")[0]) < 2:
+
+    class DatabagModel(BaseModel):  # type: ignore
+        """Base databag model."""
+
+        class Config:
+            """Pydantic config."""
+
+            # ignore any extra fields in the databag
+            extra = "ignore"
+            """Ignore any extra fields in the databag."""
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            if cls._NEST_UNDER:
+                return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {f.alias for f in cls.__fields__.values()}
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                logger.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.parse_raw(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                logger.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+
+            if self._NEST_UNDER:
+                databag[self._NEST_UNDER] = self.json(by_alias=True)
+                return databag
+
+            dct = self.dict()
+            for key, field in self.__fields__.items():  # type: ignore
+                value = dct[key]
+                databag[field.alias or key] = json.dumps(value)
+
+            return databag
+
+else:
+    from pydantic import ConfigDict
+
+    class DatabagModel(BaseModel):
+        """Base databag model."""
+
+        model_config = ConfigDict(
+            # ignore any extra fields in the databag
+            extra="ignore",
+            # Allow instantiating this class by field name (instead of forcing alias).
+            populate_by_name=True,
+            # Custom config key: whether to nest the whole datastructure (as json)
+            # under a field or spread it out at the toplevel.
+            _NEST_UNDER=None,  # type: ignore
+        )
+        """Pydantic config."""
+
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            nest_under = cls.model_config.get("_NEST_UNDER")  # type: ignore
+            if nest_under:
+                return cls.model_validate(json.loads(databag[nest_under]))  # type: ignore
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {(f.alias or n) for n, f in cls.__fields__.items()}
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                logger.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.model_validate_json(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                logger.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+            nest_under = self.model_config.get("_NEST_UNDER")
+            if nest_under:
+                databag[nest_under] = self.model_dump_json(  # type: ignore
+                    by_alias=True,
+                    # skip keys whose values are default
+                    exclude_defaults=True,
+                )
+                return databag
+
+            dct = self.model_dump()  # type: ignore
+            for key, field in self.model_fields.items():  # type: ignore
+                value = dct[key]
+                if value == field.default:
+                    continue
+                databag[field.alias or key] = json.dumps(value)
+
+            return databag
+
+
+# todo use models from charm-relation-interfaces
+if int(pydantic.version.VERSION.split(".")[0]) < 2:
+
+    class ProtocolType(BaseModel):  # type: ignore
+        """Protocol Type."""
+
+        class Config:
+            """Pydantic config."""
+
+            use_enum_values = True
+            """Allow serializing enum values."""
+
+        name: str = Field(
+            ...,
+            description="Receiver protocol name. What protocols are supported (and what they are called) "
+            "may differ per provider.",
+            examples=["otlp_grpc", "otlp_http", "tempo_http"],
+        )
+
+        type: TransportProtocolType = Field(
+            ...,
+            description="The transport protocol used by this receiver.",
+            examples=["http", "grpc"],
+        )
+
+else:
+
+    class ProtocolType(BaseModel):
+        """Protocol Type."""
+
+        model_config = ConfigDict(  # type: ignore
+            # Allow serializing enum values.
+            use_enum_values=True
+        )
+        """Pydantic config."""
+
+        name: str = Field(
+            ...,
+            description="Receiver protocol name. What protocols are supported (and what they are called) "
+            "may differ per provider.",
+            examples=["otlp_grpc", "otlp_http", "tempo_http"],
+        )
+
+        type: TransportProtocolType = Field(
+            ...,
+            description="The transport protocol used by this receiver.",
+            examples=["http", "grpc"],
+        )
+
+
+class Receiver(BaseModel):
+    """Specification of an active receiver."""
+
+    protocol: ProtocolType = Field(..., description="Receiver protocol name and type.")
+    url: str = Field(
+        ...,
+        description="""URL at which the receiver is reachable. If there's an ingress, it would be the external URL.
+        Otherwise, it would be the service's fqdn or internal IP.
+        If the protocol type is grpc, the url will not contain a scheme.""",
+        examples=[
+            "http://traefik_address:2331",
+            "https://traefik_address:2331",
+            "http://tempo_public_ip:2331",
+            "https://tempo_public_ip:2331",
+            "tempo_public_ip:2331",
+        ],
+    )
+
+
+class TracingProviderAppData(DatabagModel):  # noqa: D101
+    """Application databag model for the tracing provider."""
+
+    receivers: List[Receiver] = Field(
+        ...,
+        description="List of all receivers enabled on the tracing provider.",
+    )
+
+
+class TracingRequirerAppData(DatabagModel):  # noqa: D101
+    """Application databag model for the tracing requirer."""
+
+    receivers: List[ReceiverProtocol]
+    """Requested receivers."""
+
+
+class _AutoSnapshotEvent(RelationEvent):
+    __args__: Tuple[str, ...] = ()
+    __optional_kwargs__: Dict[str, Any] = {}
+
+    @classmethod
+    def __attrs__(cls):
+        return cls.__args__ + tuple(cls.__optional_kwargs__.keys())
+
+    def __init__(self, handle, relation, *args, **kwargs):
+        super().__init__(handle, relation)
+
+        if not len(self.__args__) == len(args):
+            raise TypeError("expected {} args, got {}".format(len(self.__args__), len(args)))
+
+        for attr, obj in zip(self.__args__, args):
+            setattr(self, attr, obj)
+        for attr, default in self.__optional_kwargs__.items():
+            obj = kwargs.get(attr, default)
+            setattr(self, attr, obj)
+
+    def snapshot(self) -> dict:
+        dct = super().snapshot()
+        for attr in self.__attrs__():
+            obj = getattr(self, attr)
+            try:
+                dct[attr] = obj
+            except ValueError as e:
+                raise ValueError(
+                    "cannot automagically serialize {}: "
+                    "override this method and do it "
+                    "manually.".format(obj)
+                ) from e
+
+        return dct
+
+    def restore(self, snapshot: dict) -> None:
+        super().restore(snapshot)
+        for attr, obj in snapshot.items():
+            setattr(self, attr, obj)
+
+
+class RelationNotFoundError(Exception):
+    """Raised if no relation with the given name is found."""
+
+    def __init__(self, relation_name: str):
+        self.relation_name = relation_name
+        self.message = "No relation named '{}' found".format(relation_name)
+        super().__init__(self.message)
+
+
+class RelationInterfaceMismatchError(Exception):
+    """Raised if the relation with the given name has an unexpected interface."""
+
+    def __init__(
+        self,
+        relation_name: str,
+        expected_relation_interface: str,
+        actual_relation_interface: str,
+    ):
+        self.relation_name = relation_name
+        self.expected_relation_interface = expected_relation_interface
+        self.actual_relation_interface = actual_relation_interface
+        self.message = (
+            "The '{}' relation has '{}' as interface rather than the expected '{}'".format(
+                relation_name, actual_relation_interface, expected_relation_interface
+            )
+        )
+
+        super().__init__(self.message)
+
+
+class RelationRoleMismatchError(Exception):
+    """Raised if the relation with the given name has a different role than expected."""
+
+    def __init__(
+        self,
+        relation_name: str,
+        expected_relation_role: RelationRole,
+        actual_relation_role: RelationRole,
+    ):
+        self.relation_name = relation_name
+        self.expected_relation_interface = expected_relation_role
+        self.actual_relation_role = actual_relation_role
+        self.message = "The '{}' relation has role '{}' rather than the expected '{}'".format(
+            relation_name, repr(actual_relation_role), repr(expected_relation_role)
+        )
+
+        super().__init__(self.message)
+
+
+def _validate_relation_by_interface_and_direction(
+    charm: CharmBase,
+    relation_name: str,
+    expected_relation_interface: str,
+    expected_relation_role: RelationRole,
+):
+    """Validate a relation.
+
+    Verifies that the `relation_name` provided: (1) exists in metadata.yaml,
+    (2) declares as interface the interface name passed as `relation_interface`
+    and (3) has the right "direction", i.e., it is a relation that `charm`
+    provides or requires.
+
+    Args:
+        charm: a `CharmBase` object to scan for the matching relation.
+        relation_name: the name of the relation to be verified.
+        expected_relation_interface: the interface name to be matched by the
+            relation named `relation_name`.
+        expected_relation_role: whether the `relation_name` must be either
+            provided or required by `charm`.
+
+    Raises:
+        RelationNotFoundError: If there is no relation in the charm's metadata.yaml
+            with the same name as provided via `relation_name` argument.
+        RelationInterfaceMismatchError: The relation with the same name as provided
+            via `relation_name` argument does not have the same relation interface
+            as specified via the `expected_relation_interface` argument.
+        RelationRoleMismatchError: If the relation with the same name as provided
+            via `relation_name` argument does not have the same role as specified
+            via the `expected_relation_role` argument.
+    """
+    if relation_name not in charm.meta.relations:
+        raise RelationNotFoundError(relation_name)
+
+    relation = charm.meta.relations[relation_name]
+
+    # fixme: why do we need to cast here?
+    actual_relation_interface = cast(str, relation.interface_name)
+
+    if actual_relation_interface != expected_relation_interface:
+        raise RelationInterfaceMismatchError(
+            relation_name, expected_relation_interface, actual_relation_interface
+        )
+
+    if expected_relation_role is RelationRole.provides:
+        if relation_name not in charm.meta.provides:
+            raise RelationRoleMismatchError(
+                relation_name, RelationRole.provides, RelationRole.requires
+            )
+    elif expected_relation_role is RelationRole.requires:
+        if relation_name not in charm.meta.requires:
+            raise RelationRoleMismatchError(
+                relation_name, RelationRole.requires, RelationRole.provides
+            )
+    else:
+        raise TypeError("Unexpected RelationDirection: {}".format(expected_relation_role))
+
+
+class RequestEvent(RelationEvent):
+    """Event emitted when a remote requests a tracing endpoint."""
+
+    @property
+    def requested_receivers(self) -> List[ReceiverProtocol]:
+        """List of receiver protocols that have been requested."""
+        relation = self.relation
+        app = relation.app
+        if not app:
+            raise NotReadyError("relation.app is None")
+
+        return TracingRequirerAppData.load(relation.data[app]).receivers
+
+
+class BrokenEvent(RelationBrokenEvent):
+    """Event emitted when a relation on tracing is broken."""
+
+
+class TracingEndpointProviderEvents(CharmEvents):
+    """TracingEndpointProvider events."""
+
+    request = EventSource(RequestEvent)
+    broken = EventSource(BrokenEvent)
+
+
+class TracingEndpointProvider(Object):
+    """Class representing a trace receiver service."""
+
+    on = TracingEndpointProviderEvents()  # type: ignore
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        external_url: Optional[str] = None,
+        relation_name: str = DEFAULT_RELATION_NAME,
+    ):
+        """Initialize.
+
+        Args:
+            charm: a `CharmBase` instance that manages this instance of the Tempo service.
+            external_url: external address of the node hosting the tempo server,
+                if an ingress is present.
+            relation_name: an optional string name of the relation between `charm`
+                and the Tempo charmed service. The default is "tracing".
+
+        Raises:
+            RelationNotFoundError: If there is no relation in the charm's metadata.yaml
+                with the same name as provided via `relation_name` argument.
+            RelationInterfaceMismatchError: The relation with the same name as provided
+                via `relation_name` argument does not have the `tracing` relation
+                interface.
+            RelationRoleMismatchError: If the relation with the same name as provided
+                via `relation_name` argument does not have the `RelationRole.requires`
+                role.
+        """
+        _validate_relation_by_interface_and_direction(
+            charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.provides
+        )
+
+        super().__init__(charm, relation_name + "tracing-provider")
+        self._charm = charm
+        self._external_url = external_url
+        self._relation_name = relation_name
+        self.framework.observe(
+            self._charm.on[relation_name].relation_joined, self._on_relation_event
+        )
+        self.framework.observe(
+            self._charm.on[relation_name].relation_created, self._on_relation_event
+        )
+        self.framework.observe(
+            self._charm.on[relation_name].relation_changed, self._on_relation_event
+        )
+        self.framework.observe(
+            self._charm.on[relation_name].relation_broken, self._on_relation_broken_event
+        )
+
+    def _on_relation_broken_event(self, e: RelationBrokenEvent):
+        """Handle relation broken events."""
+        self.on.broken.emit(e.relation)
+
+    def _on_relation_event(self, e: RelationEvent):
+        """Handle relation created/joined/changed events."""
+        if self.is_requirer_ready(e.relation):
+            self.on.request.emit(e.relation)
+
+    def is_requirer_ready(self, relation: Relation):
+        """Attempt to determine if requirer has already populated app data."""
+        try:
+            self._get_requested_protocols(relation)
+        except NotReadyError:
+            return False
+        return True
+
+    @staticmethod
+    def _get_requested_protocols(relation: Relation):
+        app = relation.app
+        if not app:
+            raise NotReadyError("relation.app is None")
+
+        try:
+            databag = TracingRequirerAppData.load(relation.data[app])
+        except (json.JSONDecodeError, pydantic.ValidationError, DataValidationError):
+            logger.info(f"relation {relation} is not ready to talk tracing")
+            raise NotReadyError()
+        return databag.receivers
+
+    def requested_protocols(self):
+        """All receiver protocols that have been requested by our related apps."""
+        requested_protocols = set()
+        for relation in self.relations:
+            try:
+                protocols = self._get_requested_protocols(relation)
+            except NotReadyError:
+                continue
+            requested_protocols.update(protocols)
+        return requested_protocols
+
+    @property
+    def relations(self) -> List[Relation]:
+        """All relations active on this endpoint."""
+        return self._charm.model.relations[self._relation_name]
+
+    def publish_receivers(self, receivers: Sequence[RawReceiver]):
+        """Let all requirers know that these receivers are active and listening."""
+        if not self._charm.unit.is_leader():
+            raise RuntimeError("only leader can do this")
+
+        for relation in self.relations:
+            try:
+                TracingProviderAppData(
+                    receivers=[
+                        Receiver(
+                            url=url,
+                            protocol=ProtocolType(
+                                name=protocol,
+                                type=receiver_protocol_to_transport_protocol[protocol],
+                            ),
+                        )
+                        for protocol, url in receivers
+                    ],
+                ).dump(relation.data[self._charm.app])
+
+            except ModelError as e:
+                # args are bytes
+                msg = e.args[0]
+                if isinstance(msg, bytes):
+                    if msg.startswith(
+                        b"ERROR cannot read relation application settings: permission denied"
+                    ):
+                        logger.error(
+                            f"encountered error {e} while attempting to update_relation_data."
+                            f"The relation must be gone."
+                        )
+                        continue
+                raise
+
+
+class EndpointRemovedEvent(RelationBrokenEvent):
+    """Event representing a change in one of the receiver endpoints."""
+
+
+class EndpointChangedEvent(_AutoSnapshotEvent):
+    """Event representing a change in one of the receiver endpoints."""
+
+    __args__ = ("_receivers",)
+
+    if TYPE_CHECKING:
+        _receivers = []  # type: List[dict]
+
+    @property
+    def receivers(self) -> List[Receiver]:
+        """Cast receivers back from dict."""
+        return [Receiver(**i) for i in self._receivers]
+
+
+class TracingEndpointRequirerEvents(CharmEvents):
+    """TracingEndpointRequirer events."""
+
+    endpoint_changed = EventSource(EndpointChangedEvent)
+    endpoint_removed = EventSource(EndpointRemovedEvent)
+
+
+class TracingEndpointRequirer(Object):
+    """A tracing endpoint for Tempo."""
+
+    on = TracingEndpointRequirerEvents()  # type: ignore
+
+    def __init__(
+        self,
+        charm: CharmBase,
+        relation_name: str = DEFAULT_RELATION_NAME,
+        protocols: Optional[List[ReceiverProtocol]] = None,
+    ):
+        """Construct a tracing requirer for a Tempo charm.
+
+        If your application supports pushing traces to a distributed tracing backend, the
+        `TracingEndpointRequirer` object enables your charm to easily access endpoint information
+        exchanged over a `tracing` relation interface.
+
+        Args:
+            charm: a `CharmBase` object that manages this
+                `TracingEndpointRequirer` object. Typically, this is `self` in the instantiating
+                class.
+            relation_name: an optional string name of the relation between `charm`
+                and the Tempo charmed service. The default is "tracing". It is strongly
+                advised not to change the default, so that people deploying your charm will have a
+                consistent experience with all other charms that provide tracing endpoints.
+            protocols: optional list of protocols that the charm intends to send traces with.
+                The provider will enable receivers for these and only these protocols,
+                so be sure to enable all protocols the charm or its workload are going to need.
+
+        Raises:
+            RelationNotFoundError: If there is no relation in the charm's metadata.yaml
+                with the same name as provided via `relation_name` argument.
+            RelationInterfaceMismatchError: The relation with the same name as provided
+                via `relation_name` argument does not have the `tracing` relation
+                interface.
+            RelationRoleMismatchError: If the relation with the same name as provided
+                via `relation_name` argument does not have the `RelationRole.provides`
+                role.
+        """
+        _validate_relation_by_interface_and_direction(
+            charm, relation_name, RELATION_INTERFACE_NAME, RelationRole.requires
+        )
+
+        super().__init__(charm, relation_name)
+
+        self._is_single_endpoint = charm.meta.relations[relation_name].limit == 1
+
+        self._charm = charm
+        self._relation_name = relation_name
+
+        events = self._charm.on[self._relation_name]
+        self.framework.observe(events.relation_changed, self._on_tracing_relation_changed)
+        self.framework.observe(events.relation_broken, self._on_tracing_relation_broken)
+
+        if protocols and self._charm.unit.is_leader():
+            # we can't be sure that the current event context supports read/writing relation data for this relation,
+            # so we catch ModelErrors. This is because we're doing this in init.
+            try:
+                self.request_protocols(protocols)
+            except ModelError as e:
+                logger.error(
+                    f"encountered error {e} while attempting to request_protocols."
+                    f"The relation must be gone."
+                )
+                pass
+
+    def request_protocols(
+        self, protocols: Sequence[ReceiverProtocol], relation: Optional[Relation] = None
+    ):
+        """Publish the list of protocols which the provider should activate."""
+        # todo: should we check if _is_single_endpoint and len(self.relations) > 1 and raise, here?
+        relations = [relation] if relation else self.relations
+
+        if not protocols:
+            # empty sequence
+            raise ValueError(
+                "You need to pass a nonempty sequence of protocols to `request_protocols`."
+            )
+
+        if self._charm.unit.is_leader():
+            for relation in relations:
+                TracingRequirerAppData(
+                    receivers=list(protocols),
+                ).dump(relation.data[self._charm.app])
+        else:
+            raise DataAccessPermissionError("only leaders can request_protocols")
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The tracing relations associated with this endpoint."""
+        return self._charm.model.relations[self._relation_name]
+
+    @property
+    def _relation(self) -> Optional[Relation]:
+        """If this wraps a single endpoint, the relation bound to it, if any."""
+        if not self._is_single_endpoint:
+            objname = type(self).__name__
+            raise AmbiguousRelationUsageError(
+                f"This {objname} wraps a {self._relation_name} endpoint that has "
+                "limit != 1. We can't determine what relation, of the possibly many, you are "
+                f"talking about. Please pass a relation instance while calling {objname}, "
+                "or set limit=1 in the charm metadata."
+            )
+        relations = self.relations
+        return relations[0] if relations else None
+
+    def is_ready(self, relation: Optional[Relation] = None):
+        """Is this endpoint ready?"""
+        relation = relation or self._relation
+        if not relation:
+            logger.debug(f"no relation on {self._relation_name !r}: tracing not ready")
+            return False
+        if relation.data is None:
+            logger.error(f"relation data is None for {relation}")
+            return False
+        if not relation.app:
+            logger.error(f"{relation} event received but there is no relation.app")
+            return False
+        try:
+            databag = dict(relation.data[relation.app])
+            TracingProviderAppData.load(databag)
+
+        except (json.JSONDecodeError, pydantic.ValidationError, DataValidationError):
+            logger.info(f"failed validating relation data for {relation}")
+            return False
+        return True
+
+    def _on_tracing_relation_changed(self, event):
+        """Notify the providers that there is new endpoint information available."""
+        relation = event.relation
+        if not self.is_ready(relation):
+            self.on.endpoint_removed.emit(relation)  # type: ignore
+            return
+
+        data = TracingProviderAppData.load(relation.data[relation.app])
+        self.on.endpoint_changed.emit(relation, [i.dict() for i in data.receivers])  # type: ignore
+
+    def _on_tracing_relation_broken(self, event: RelationBrokenEvent):
+        """Notify the providers that the endpoint is broken."""
+        relation = event.relation
+        self.on.endpoint_removed.emit(relation)  # type: ignore
+
+    def get_all_endpoints(
+        self, relation: Optional[Relation] = None
+    ) -> Optional[TracingProviderAppData]:
+        """Unmarshalled relation data."""
+        relation = relation or self._relation
+        if not self.is_ready(relation):
+            return
+        return TracingProviderAppData.load(relation.data[relation.app])  # type: ignore
+
+    def _get_endpoint(
+        self, relation: Optional[Relation], protocol: ReceiverProtocol
+    ) -> Optional[str]:
+        app_data = self.get_all_endpoints(relation)
+        if not app_data:
+            return None
+        receivers: List[Receiver] = list(
+            filter(lambda i: i.protocol.name == protocol, app_data.receivers)
+        )
+        if not receivers:
+            # it can happen if the charm requests tracing protocols, but the relay (such as grafana-agent) isn't yet
+            # connected to the tracing backend. In this case, it's not an error the charm author can do anything about
+            logger.warning(f"no receiver found with protocol={protocol!r}.")
+            return
+        if len(receivers) > 1:
+            # if we have more than 1 receiver that matches, it shouldn't matter which receiver we'll be using.
+            logger.warning(
+                f"too many receivers with protocol={protocol!r}; using first one. Found: {receivers}"
+            )
+
+        receiver = receivers[0]
+        return receiver.url
+
+    def get_endpoint(
+        self, protocol: ReceiverProtocol, relation: Optional[Relation] = None
+    ) -> Optional[str]:
+        """Receiver endpoint for the given protocol.
+
+        It could happen that this function gets called before the provider publishes the endpoints.
+        In such a scenario, if a non-leader unit calls this function, a permission denied exception will be raised due to
+        restricted access. To prevent this, this function needs to be guarded by the `is_ready` check.
+
+        Raises:
+        ProtocolNotRequestedError:
+            If the charm unit is the leader unit and attempts to obtain an endpoint for a protocol it did not request.
+        """
+        endpoint = self._get_endpoint(relation or self._relation, protocol=protocol)
+        if not endpoint:
+            requested_protocols = set()
+            relations = [relation] if relation else self.relations
+            for relation in relations:
+                try:
+                    databag = TracingRequirerAppData.load(relation.data[self._charm.app])
+                except DataValidationError:
+                    continue
+
+                requested_protocols.update(databag.receivers)
+
+            if protocol not in requested_protocols:
+                raise ProtocolNotRequestedError(protocol, relation)
+
+            return None
+        return endpoint
+
+
+def charm_tracing_config(
+    endpoint_requirer: TracingEndpointRequirer, cert_path: Optional[Union[Path, str]]
+) -> Tuple[Optional[str], Optional[str]]:
+    """Return the charm_tracing config you likely want.
+
+    If no endpoint is provided:
+     disable charm tracing.
+    If https endpoint is provided but cert_path is not found on disk:
+     disable charm tracing.
+    If https endpoint is provided and cert_path is None:
+     ERROR
+    Else:
+     proceed with charm tracing (with or without tls, as appropriate)
+
+    Usage:
+    >>> from lib.charms.tempo_coordinator_k8s.v0.charm_tracing import trace_charm
+    >>> from lib.charms.tempo_coordinator_k8s.v0.tracing import charm_tracing_config
+    >>> @trace_charm(tracing_endpoint="my_endpoint", cert_path="cert_path")
+    >>> class MyCharm(...):
+    >>>     _cert_path = "/path/to/cert/on/charm/container.crt"
+    >>>     def __init__(self, ...):
+    >>>         self.tracing = TracingEndpointRequirer(...)
+    >>>         self.my_endpoint, self.cert_path = charm_tracing_config(
+    ...             self.tracing, self._cert_path)
+    """
+    if not endpoint_requirer.is_ready():
+        return None, None
+
+    try:
+        endpoint = endpoint_requirer.get_endpoint("otlp_http")
+    except ModelError as e:
+        if e.args[0] == "ERROR permission denied\n":
+            # this can happen the app databag doesn't have data,
+            # or we're breaking the relation.
+            return None, None
+        raise
+
+    if not endpoint:
+        return None, None
+
+    is_https = endpoint.startswith("https://")
+
+    if is_https:
+        if cert_path is None or not Path(cert_path).exists():
+            # disable charm tracing until we obtain a cert to prevent tls errors
+            logger.error(
+                "Tracing endpoint is https, but no server_cert has been passed."
+                "Please point @trace_charm to a `server_cert` attr. "
+                "This might also mean that the tracing provider is related to a "
+                "certificates provider, but this application is not (yet). "
+                "In that case, you might just have to wait a bit for the certificates "
+                "integration to settle. "
+            )
+            return None, None
+        return endpoint, str(cert_path)
+    else:
+        return endpoint, None

--- a/src/charm.py
+++ b/src/charm.py
@@ -114,7 +114,7 @@ class AMFOperatorCharm(CharmBase):
                 }
             ],
         )
-        self.charm_tracing = ops.tracing.Tracing(self, "charm-tracing")
+        self.charm_tracing = ops.tracing.Tracing(self, "charm_tracing")
         self.tracing = TracingEndpointRequirer(
             charm=self,
             relation_name="tracing",

--- a/src/templates/amfcfg.conf.j2
+++ b/src/templates/amfcfg.conf.j2
@@ -67,8 +67,8 @@ configuration:
     enable: true
     expireTime: 6s
     maxRetryTimes: 4
-  telemetry:                                 
-    enabled: {{ telemetry.enabled }} 
+  telemetry:
+    enabled: {{ telemetry.enabled }}
     otlp_endpoint: {{ telemetry.otlp_endpoint }}
     ratio: {{ telemetry.ratio }}
 logger:

--- a/src/templates/amfcfg.conf.j2
+++ b/src/templates/amfcfg.conf.j2
@@ -68,7 +68,7 @@ configuration:
     expireTime: 6s
     maxRetryTimes: 4
   telemetry:
-    enabled: {{ telemetry.enabled }}
+    enabled: {{ telemetry.enabled | lower }}
     otlp_endpoint: {{ telemetry.otlp_endpoint }}
     ratio: {{ telemetry.ratio }}
 logger:

--- a/src/templates/amfcfg.conf.j2
+++ b/src/templates/amfcfg.conf.j2
@@ -67,6 +67,10 @@ configuration:
     enable: true
     expireTime: 6s
     maxRetryTimes: 4
+  telemetry:                                 
+    enabled: {{ telemetry.enabled }} 
+    otlp_endpoint: {{ telemetry.otlp_endpoint }}
+    ratio: {{ telemetry.ratio }}
 logger:
   AMF:
     debugLevel: {{ log_level }}

--- a/tests/unit/expected_config/config.conf
+++ b/tests/unit/expected_config/config.conf
@@ -67,6 +67,10 @@ configuration:
     enable: true
     expireTime: 6s
     maxRetryTimes: 4
+  telemetry:
+    enabled: False
+    otlp_endpoint: 
+    ratio: 0.0
 logger:
   AMF:
     debugLevel: info

--- a/tests/unit/expected_config/config.conf
+++ b/tests/unit/expected_config/config.conf
@@ -68,7 +68,7 @@ configuration:
     expireTime: 6s
     maxRetryTimes: 4
   telemetry:
-    enabled: False
+    enabled: false
     otlp_endpoint: 
     ratio: 0.0
 logger:

--- a/uv.lock
+++ b/uv.lock
@@ -473,7 +473,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -985,7 +985,7 @@ wheels = [
 
 [[package]]
 name = "ops"
-version = "2.21.1"
+version = "2.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "importlib-metadata" },
@@ -993,9 +993,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/97/c5/f0098a9b1b72680b3682043227a628a08a7b5b9592fc98ea6efa0d638017/ops-2.21.1.tar.gz", hash = "sha256:4a8190420813ba37e7a0399d656008f99c79015d7f72e138bad7cb1ac403d0b0", size = 496427, upload-time = "2025-05-01T03:03:23.038Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/44/b13d1722ea3211390a9ba3c65acb7c8806168858d8568dcb52192fff161d/ops-2.22.0.tar.gz", hash = "sha256:bd1cd1229e83efb8ae2d97d8878c7db3deceb6819eb5a38fb6e235a959528ec2", size = 500975, upload-time = "2025-05-29T04:18:46.521Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e6/c7/b70271ee12418144d5c596f37745c21da105470d365d834a9fce071f7bc2/ops-2.21.1-py3-none-any.whl", hash = "sha256:6745084c8e73bc485c254f95664bd85ddcf786c91b90782f2830c8333a1440b2", size = 182682, upload-time = "2025-05-01T03:03:20.946Z" },
+    { url = "https://files.pythonhosted.org/packages/19/09/9636766721d4d34fc0fc768d0c74f006a772368d5e68ceba6b9c32407ce5/ops-2.22.0-py3-none-any.whl", hash = "sha256:ad44326bc065e33357b47e1cf4c73e811b2fdb3c89dd0c9bdf421a7a028bdcf7", size = 182680, upload-time = "2025-05-29T04:18:44.01Z" },
 ]
 
 [package.optional-dependencies]
@@ -1005,29 +1005,29 @@ tracing = [
 
 [[package]]
 name = "ops-scenario"
-version = "7.21.1"
+version = "7.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ops" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/95/90312165f3e1d5876872ad64131be9c0f26b5aa09bd73a436a21b0752820/ops_scenario-7.21.1.tar.gz", hash = "sha256:534b407b34212161c3e74cb396b79ca7449932e483053e924146fdf0140876b9", size = 141631, upload-time = "2025-05-01T03:03:30.456Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/65/13f60a4f0ba54f6731733ece46e98276fef62c48b62f80c1a9501f46f28f/ops_scenario-7.22.0.tar.gz", hash = "sha256:15921e6849773b81df90ad4d78f573e0af5f5b9ddbfc82603c991c29648d8070", size = 142308, upload-time = "2025-05-29T04:18:49.194Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/3b/4cc28ea9d77015ecf8fc5c3d362bb274e35ffaa2e6fbd87909a5384afa40/ops_scenario-7.21.1-py3-none-any.whl", hash = "sha256:eeb9def2c31a1db2429cf21bd9b8cbd2ac092cc1fbe5591e850e4aa192c542fa", size = 72451, upload-time = "2025-05-01T03:03:28.488Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/9c/1abc3c03a27eccb2580df035a78e0115c1dc29f6f379c9465990f69d0913/ops_scenario-7.22.0-py3-none-any.whl", hash = "sha256:a42d3acf831fc46f213286268e31d14c2ffc5ea72452c49955de76895f62437c", size = 72506, upload-time = "2025-05-29T04:18:46.657Z" },
 ]
 
 [[package]]
 name = "ops-tracing"
-version = "2.21.1"
+version = "2.22.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "opentelemetry-sdk" },
     { name = "ops" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/cd/1d/8c028b996ef5cc320064e63b8497cc95dbd4cb6be730012f12046ac50d43/ops_tracing-2.21.1.tar.gz", hash = "sha256:d1dc8ecd079a4d78f3d6978bda16b884d1dc00792db0d8e9273912a87cf2cafc", size = 27871, upload-time = "2025-05-01T03:03:18.482Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6b/00dbf4ef4d477817dd129c45497c1fee330e2465735318595eae3d8d6ade/ops_tracing-2.22.0.tar.gz", hash = "sha256:238ede5e9268f81deefce9275d2c846bd2726f1bf17f2f74bdf07432d147f2cd", size = 28191, upload-time = "2025-05-29T04:18:44.884Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/22/d75274cd8775a016b925fd7a3a4040b890a3be797285d4f6c56ab0c2b471/ops_tracing-2.21.1-py3-none-any.whl", hash = "sha256:e84900361806481e74b0c1855c52a85552a3a3edaaea06f47846f934a2ffa5b2", size = 31177, upload-time = "2025-05-01T03:03:16.918Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/5b/b0f11278f19bfd8250a52d837cf38a29d78e1200610becdf70a9cc20ab5a/ops_tracing-2.22.0-py3-none-any.whl", hash = "sha256:f47bf9fd35e47bab2499de7428bc2433534e6331ff6ec1ab533f31a48b1341f4", size = 31245, upload-time = "2025-05-29T04:18:43.168Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Description

Add amf tracing support at the charm level.

## To do prior to merging this PR

- Merge upstream PR: https://github.com/omec-project/amf/pull/473
- Update container image

## Limitations

There is a known issue in Grafana Agent K8s which prevents from tailing traces for services that do not match the `.+-charm` regex. We can workaround this issue by integrating directly to Tempo instead.
- Reference: https://github.com/canonical/grafana-agent-k8s-operator/issues/389

# Checklist:

- [ ] My code follows the [style guidelines](https://github.com/canonical/sdcore-amf-k8s-operator/blob/main/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
