### PR TITLE
chore: update shared renovate file reference

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,4 +1,4 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": ["https://raw.githubusercontent.com/canonical/sdcore-github-workflows/refs/heads/main/renovate.json5"]
+    "extends": ["github>canonical/sdcore-github-workflows:renovate.json5"]
 }


### PR DESCRIPTION
# Description

Renovate stopped creating PR's.  We were using a link to shared renovate file raw file content but  renovate suggests to use following structure to give reference to shared renovate file. Hence, this PR changes the extends part to apply suggested approach.
```
GitHub with preset name 	github>abc/foo:xyz 	xyz 	https://github.com/abc/foo 	xyz.json 	Default branch
```
https://docs.renovatebot.com/config-presets/

# Checklist:

- [ ] My code follows the [style guidelines](https://github.com/canonical/sdcore-amf-k8s-operator/blob/main/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
