### PR TITLE
feat: make DNN configurable (clean up charm config)

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -83,10 +83,6 @@ config:
       type: string
       default: info
       description: Log level for the AMF. One of `debug`, `info`, `warn`, `error`, `fatal`, `panic`.
-    dnn:
-      type: string
-      default: internet
-      description: Data Network Name (DNN)
     external-amf-ip:
       type: string
       description: |-

--- a/src/charm.py
+++ b/src/charm.py
@@ -465,14 +465,9 @@ class AMFOperatorCharm(CharmBase):
             list: List of strings matching config keys.
         """
         invalid_configs = []
-        if not self._get_dnn_config():
-            invalid_configs.append("dnn")
         if not self._is_log_level_valid():
             invalid_configs.append("log-level")
         return invalid_configs
-
-    def _get_dnn_config(self) -> Optional[str]:
-        return cast(Optional[str], self.model.config.get("dnn"))
 
     def _get_log_level_config(self) -> Optional[str]:
         return cast(Optional[str], self.model.config.get("log-level"))
@@ -550,8 +545,6 @@ class AMFOperatorCharm(CharmBase):
         Returns:
             content (str): desired config file content
         """
-        if not (dnn := self._get_dnn_config()):
-            raise ValueError("DNN configuration value is empty")
         if not (pod_ip := _get_pod_ip()):
             raise ValueError("Pod IP is not available")
         if not self._nrf_requires.nrf_url:
@@ -569,7 +562,6 @@ class AMFOperatorCharm(CharmBase):
             amf_ip=pod_ip,
             full_network_name=CORE_NETWORK_FULL_NAME,
             short_network_name=CORE_NETWORK_SHORT_NAME,
-            dnn=dnn,
             scheme="https",
             webui_uri=self._webui_requires.webui_url,
             log_level=log_level,
@@ -587,7 +579,6 @@ class AMFOperatorCharm(CharmBase):
         nrf_url: str,
         full_network_name: str,
         short_network_name: str,
-        dnn: str,
         scheme: str,
         webui_uri: str,
         log_level: str,
@@ -604,7 +595,6 @@ class AMFOperatorCharm(CharmBase):
             nrf_url (str): URL of the NRF.
             full_network_name (str): Full name of the network.
             short_network_name (str): Short name of the network.
-            dnn (str): Data Network name.
             scheme (str): SBI interface scheme ("http" or "https")
             webui_uri (str) : URL of the Webui.
             log_level (str): Log level for the AMF.
@@ -624,7 +614,6 @@ class AMFOperatorCharm(CharmBase):
             amf_ip=amf_ip,
             full_network_name=full_network_name,
             short_network_name=short_network_name,
-            dnn=dnn,
             scheme=scheme,
             webui_uri=webui_uri,
             log_level=log_level,

--- a/src/templates/amfcfg.conf.j2
+++ b/src/templates/amfcfg.conf.j2
@@ -34,8 +34,6 @@ configuration:
     - namf-mt
     - namf-loc
     - namf-oam
-  supportDnnList:
-    - {{ dnn }}
   security:
     integrityOrder:
       - NIA1

--- a/tests/unit/expected_config/config.conf
+++ b/tests/unit/expected_config/config.conf
@@ -34,8 +34,6 @@ configuration:
     - namf-mt
     - namf-loc
     - namf-oam
-  supportDnnList:
-    - internet
   security:
     integrityOrder:
       - NIA1


### PR DESCRIPTION
# Description

The AMF charm sets the `supportDnnList` value in the configuration file. This value is only used by the AMF if the UE's subscription information received from the UDM does not contain the default DNN (this is not the case in Charmed Aether SD-Core). 

We are allowing the user to set custom DNN values using the UI. Keeping this field does not align with the dynamic nature of the configuration and could lead to confusion

See https://github.com/omec-project/amf/pull/482


# Checklist:

- [ ] My code follows the [style guidelines](https://github.com/canonical/sdcore-amf-k8s-operator/blob/main/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
